### PR TITLE
Feature/synonym schema

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
@@ -1333,7 +1333,7 @@ sub add_to_syn_for_mult_sources {
     my $xref_id =
       $self->get_xref( $acc, $source_id, $species_id, $dbi );
     if ( defined $xref_id ) {
-      $self->add_synonym( $xref_id, $syn )
+      $self->add_synonym( $xref_id, $syn );
     }
   }
   return;

--- a/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
@@ -1328,18 +1328,14 @@ sub add_to_syn_for_mult_sources {
   my ( $self, $acc, $sources, $syn, $species_id, $dbi ) = @_;
 
   $dbi = $self->dbi unless defined $dbi;
-  my $add_synonym_sth =
-    $dbi->prepare('INSERT IGNORE INTO synonym VALUES(?,?)');
-
+  
   foreach my $source_id ( @{$sources} ) {
     my $xref_id =
       $self->get_xref( $acc, $source_id, $species_id, $dbi );
     if ( defined $xref_id ) {
-      $add_synonym_sth->execute( $xref_id, $syn ) or
-        croak( $dbi->errstr() . "\n $xref_id\n $syn\n" );
+      $self->add_synonym( $xref_id, $syn )
     }
   }
-  $add_synonym_sth->finish();
   return;
 }
 
@@ -1350,18 +1346,15 @@ sub add_to_syn {
   my ( $self, $acc, $source_id, $syn, $species_id, $dbi ) = @_;
 
   $dbi = $self->dbi unless defined $dbi;
-  my $add_synonym_sth =
-    $dbi->prepare('INSERT IGNORE INTO synonym VALUES(?,?)');
+  
   my $xref_id = $self->get_xref( $acc, $source_id, $species_id, $dbi );
   if ( defined $xref_id ) {
-    $add_synonym_sth->execute( $xref_id, $syn ) or
-      croak( $dbi->errstr() . "\n $xref_id\n $syn\n" );
+    $self->add_synonym( $xref_id, $syn );
   }
   else {
     carp( "Could not find acc $acc in " .
           "xref table source = $source_id of species $species_id\n" );
   }
-  $add_synonym_sth->finish();
   return;
 }
 
@@ -1373,7 +1366,7 @@ sub add_synonym {
 
   $dbi = $self->dbi unless defined $dbi;
   my $add_synonym_sth =
-    $dbi->prepare('INSERT IGNORE INTO synonym VALUES(?,?)');
+    $dbi->prepare('INSERT IGNORE INTO synonym (xref_id, synonym) VALUES(?,?)');
   $add_synonym_sth->execute( $xref_id, $syn ) or
     croak( $dbi->errstr() . "\n $xref_id\n $syn\n\n" );
 

--- a/modules/Bio/EnsEMBL/Xref/Schema/Result/Synonym.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/Result/Synonym.pm
@@ -47,7 +47,7 @@ __PACKAGE__->table("synonym");
 =head2 synonym
 
   data_type: 'varchar'
-  is_nullable: 1
+  is_nullable: 0
   size: 255
 
 =cut

--- a/modules/Bio/EnsEMBL/Xref/Schema/Result/Synonym.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/Result/Synonym.pm
@@ -58,7 +58,7 @@ __PACKAGE__->add_columns(
   "xref_id",
   { data_type => "integer", extra => { unsigned => 1 }, is_nullable => 0 },
   "synonym",
-  { data_type => "varchar", is_nullable => 1, size => 255 },
+  { data_type => "varchar", is_nullable => 0, size => 255 },
 );
 
 =head1 UNIQUE CONSTRAINTS


### PR DESCRIPTION
## Description

Pointlessly repetitious query generation removed, and the insert query receives named columns to make it more resilient to schema changes. A previously nullable column is not any more.

## Use case

Prem's unit testing efforts

## Benefits

Self-evident

## Possible Drawbacks

Good factorisation looks out of place

## Testing

No tests currently use this