### PR TITLE
Add DBASSParser, MIMParser, Mim2GeneParser and UniProtParser

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/Parser/DBASSParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/DBASSParser.pm
@@ -1,0 +1,191 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Xref::Parser::DBASSParser;
+
+# For non-destructive substitutions in regexps (/r flag)
+require 5.014_000;
+
+use strict;
+use warnings;
+
+use Carp;
+use List::Util;
+use Readonly;
+use Text::CSV;
+
+use parent qw( Bio::EnsEMBL::Xref::Parser );
+
+# This parser will read direct xrefs from a comma-delimited file downloaded from the DBASS Web site.
+# The columns of the file should be the following:
+#
+# 1)    DBASS Gene ID
+# 2)    DBASS Gene Name
+# 3)    Ensembl Gene ID
+#
+# where 2) can be either a single name, a 'name/synonym' pair, or a 'name (synonym)' pair.
+# Column values, including empty strings, can be surrounded by pairs of double quotes.
+
+
+Readonly my $EXPECTED_NUMBER_OF_COLUMNS => 3;
+
+
+sub run {
+  my ( $self ) = @_;
+  my $source_id  = $self->{source_id};
+  my $species_id = $self->{species_id};
+  my $files      = $self->{files};
+  my $verbose    = $self->{verbose} // 0;
+  my $xref_dba   = $self->{xref_dba};
+
+  my $csv = Text::CSV->new()
+    || confess 'Failed to initialise CSV parser: ' . Text::CSV->error_diag();
+
+  my $filename = @{$files}[0];
+  my $file_io = $xref_dba->get_filehandle($filename);
+
+  if ( ! is_file_header_valid( $csv->getline( $file_io ) ) ) {
+    confess "Malformed or unexpected header in DBASS file '${filename}'";
+  }
+
+  my $processed_count = 0;
+  my $unmapped_count  = 0;
+
+  while ( defined( my $line = $csv->getline( $file_io ) ) ) {
+
+    if ( scalar @{ $line } != $EXPECTED_NUMBER_OF_COLUMNS ) {
+      confess 'Line ' . (2 + $processed_count + $unmapped_count)
+        . " of input file '${filename}' has an incorrect number of columns";
+    }
+
+    # Do not modify the contents of @{$line}, only the output - hence the /r.
+    my ( $dbass_gene_id, $dbass_gene_name, $ensembl_id )
+      = map { s{\s+\z}{}rmsx } @{ $line };
+
+    # Do not attempt to create unmapped xrefs. Checking truthiness is good
+    # enough here because the only non-empty string evaluating as false is
+    # not a valid Ensembl stable ID.
+    if ( $ensembl_id ) {
+
+      # DBASS files list synonyms in two ways: either "FOO (BAR)" (with or
+      # without space) or "FOO/BAR". Both forms are relevant to us.
+      my ( $first_gene_name, $second_gene_name );
+      if ( ( $dbass_gene_name =~ m{
+                                    (.*)
+                                    \s?\/\s?  # typically no ws here but just in case
+                                    (.*)
+                                  }msx ) ||
+           ( $dbass_gene_name =~ m{
+                                    (.*)
+                                    \s?  # there are entries both with and without ws
+                                    [(] (.*) [)]
+                                  }msx ) ) {
+        $first_gene_name  = $1;
+        $second_gene_name = $2;
+      }
+      else {
+        $first_gene_name = $dbass_gene_name;
+        $second_gene_name = undef;
+      }
+
+      my $label       = $first_gene_name;
+      my $synonym     = $second_gene_name;
+      my $type        = 'gene';
+      my $version     = '1';
+
+      my $xref_id =
+        $xref_dba->get_xref( $dbass_gene_id, $source_id, $species_id );
+
+      if ( ( ! defined $xref_id ) || ( $xref_id eq q{} ) ) {
+        $xref_id = $xref_dba->add_xref({
+          acc        => $dbass_gene_id,
+          version    => $version,
+          label      => $label,
+          source_id  => $source_id,
+          species_id => $species_id,
+          info_type  => 'DIRECT'
+        });
+      }
+
+      if ( defined($synonym) ) {
+        $xref_dba->add_synonym( $xref_id, $synonym );
+      }
+
+      $xref_dba->add_direct_xref( $xref_id, $ensembl_id, $type );
+
+      ++$processed_count;
+    }
+    else {
+      ++$unmapped_count;
+    }
+
+  } ## end while ( defined( my $line...))
+
+  $csv->eof || confess 'Error parsing CSV: ' . $csv->error_diag();
+  $file_io->close();
+
+  if ($verbose) {
+    printf( "%d direct xrefs succesfully processed\n", $processed_count );
+    printf( "Skipped %d unmapped xrefs\n", $unmapped_count );
+  }
+
+  return 0;
+} ## end sub run
+
+
+=head2 is_file_header_valid
+
+  Arg [1]    : String file header line
+  Example    : if (!is_file_header_valid($header_line)) {
+                 confess 'Bad header';
+               }
+  Description: Verifies if the header of a DBASS file follows expected
+               syntax and contains expected column names.
+  Return type: boolean
+  Exceptions : none
+  Caller     : internal
+  Status     : Stable
+
+=cut
+
+sub is_file_header_valid {
+  my ( $header ) = @_;
+
+  # Don't bother with parsing column names if their number does not
+  # match to begin with
+  if ( scalar @{ $header } != $EXPECTED_NUMBER_OF_COLUMNS ) {
+    return 0;
+  }
+
+  my @fields_ok;
+
+  my ( $dbass_end ) = ( $header->[0] =~ m{ DBASS (3|5) GeneID }msx );
+  push @fields_ok, defined $dbass_end;
+
+  my $dbass_name_ok = ( $header->[1] =~ m{ DBASS ${dbass_end} GeneName }msx );
+  push @fields_ok, $dbass_name_ok;
+
+  my $ensembl_id_ok = ( $header->[2] eq 'EnsemblGeneNumber' );
+  push @fields_ok, $ensembl_id_ok;
+
+  # All fields must be in order
+  return List::Util::all { $_ } @fields_ok;
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/MIMParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/MIMParser.pm
@@ -1,0 +1,270 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Xref::Parser::MIMParser;
+
+use strict;
+use warnings;
+
+use Carp;
+use Readonly;
+
+use parent qw( Bio::EnsEMBL::Xref::Parser );
+
+# This parser will read xrefs from a record file downloaded from the
+# OMIM Web site. They should be assigned to two different xref
+# sources: MIM_GENE and MIM_MORBID. MIM xrefs are linked to EntrezGene
+# entries so the parser does not match them to Ensembl; this will be
+# taken care of when EntrezGene entries are matched.
+#
+# OMIM records are multiline. Each record begins with a specific tag
+# line and consists of a number of fields. Each field starts with its
+# own start-tag line (i.e. the data proper only appears after a
+# newline) and continues until the beginning of either the next field
+# in the same record, the next record, or the end-of-input tag. The
+# overall structure looks as follows:
+#
+#   *RECORD*
+#   *FIELD* NO
+#   *FIELD* TI
+#   *FIELD* TX
+#   ...
+#   *RECORD*
+#   *FIELD* NO
+#   *FIELD* TI
+#   ...
+#   *RECORD*
+#   *FIELD* NO
+#   ...
+#   *FIELD* CD
+#   *FIELD* ED
+#   *THEEND*
+#
+# All the data relevant to the parser can be found in the TI field.
+
+
+sub run {
+
+  my ( $self ) = @_;
+  my $general_source_id = $self->{source_id};
+  my $species_id        = $self->{species_id};
+  my $files             = $self->{files};
+  my $verbose           = $self->{verbose} // 0;
+  my $xref_dba          = $self->{xref_dba};
+
+  my $filename = @{$files}[0];
+
+  my %old_to_new;
+  my %removed;
+  my %counters;
+  my @sources;
+
+  push @sources, $general_source_id;
+
+  my $gene_source_id =
+    $xref_dba->get_source_id_for_source_name( "MIM_GENE" );
+  push @sources, $gene_source_id;
+  my $morbid_source_id =
+    $xref_dba->get_source_id_for_source_name( "MIM_MORBID" );
+  push @sources, $morbid_source_id;
+
+  Readonly my %TYPE_SINGLE_SOURCES => (
+    q{*} => $gene_source_id,
+    q{}  => $morbid_source_id,
+    q{#} => $morbid_source_id,
+    q{%} => $morbid_source_id,
+  );
+
+  if ($verbose) {
+    print "sources are: " . join( ", ", @sources ) . "\n";
+  }
+
+  IO::Handle->input_record_separator('*RECORD*');
+
+  my $mim_io = $xref_dba->get_filehandle($filename);
+
+  $mim_io->getline();    # first record is empty with *RECORD* as the
+                         # record seperator
+
+ RECORD:
+  while ( my $input_record = $mim_io->getline() ) {
+
+    my $ti = extract_ti( $input_record );
+    if ( ! defined $ti ) {
+      confess 'Failed to extract TI field from record';
+    }
+
+    my ( $type, $number, $long_desc ) = parse_ti( $ti );
+    if ( ! defined $type ) {
+      confess 'Failed to extract record type and description from TI field';
+    }
+
+    # Use the first block of text as description
+    my @fields = split( qr{;;}msx, $long_desc );
+    my $label = $fields[0] . " [" . $type . $number . "]";
+
+    my $xref_object = {
+      acc        => $number,
+      label      => $label,
+      desc       => $long_desc,
+      species_id => $species_id,
+      info_type  => 'UNMAPPED',
+    };
+
+    if ( exists $TYPE_SINGLE_SOURCES{$type} ) {
+      my $type_source = $TYPE_SINGLE_SOURCES{$type};
+
+      $xref_object->{'source_id'} = $type_source;
+      $counters{ $type_source }++;
+      $xref_dba->add_xref($xref_object);
+
+    }
+    elsif ( $type eq q{+} ) {    # both gene and phenotype
+
+      $xref_object->{'source_id'} = $gene_source_id;
+      $counters{ $gene_source_id }++;
+      $xref_dba->add_xref($xref_object);
+
+      $xref_object->{'source_id'} = $morbid_source_id;
+      $counters{ $morbid_source_id }++;
+      $xref_dba->add_xref($xref_object);
+
+    }
+    elsif ( $type eq q{^} ) {
+      my ( $new_number ) = ( $long_desc =~ m{
+                                              MOVED\sTO\s
+                                              (\d+)
+                                          }msx );
+      if ( defined $new_number ) {
+        if ( $new_number ne $number ) {
+          $old_to_new{$number} = $new_number;
+        }
+      }
+      # Both leading and trailing whitespace has been removed
+      # so don't bother with another regex match, just compare.
+      elsif ( $long_desc eq 'REMOVED FROM DATABASE' ) {
+        $removed{$number} = 1;
+        $counters{ 'removed' }++;
+      }
+      else {
+        confess "Unsupported type of a '^' record: '${long_desc}'\n";
+      }
+
+    }
+
+  } ## record loop
+
+  $mim_io->close();
+
+  # Generate synonyms from "MOVED TO" entries
+  foreach my $mim ( keys %old_to_new ) {
+    my $old = $mim;
+    my $new = $old_to_new{$old};
+
+    # Some entries in the MIM database have been moved multiple times,
+    # and we want each of the synonyms created this way to point to
+    # the *current* accession instead of one another. Keep traversing
+    # the chain of renames until we have reached the end, i.e. until
+    # $new is no longer a valid key in %old_to_new.
+    # FIXME: this is not entirely efficient, especially for long
+    # rename chains, because the foreach loop processes every single
+    # key of %old_to_new (i.e. every single "MOVED TO" entry) from
+    # scratch - even though some of them might have already been
+    # encountered in the process of traversing the change chains of
+    # previously encountered keys. Some sort of a cache pointing each
+    # of previously encountered keys to their respective final values,
+    # might be in order here.
+    # FIXME: If we do implement such a cache, compare performance for
+    # retrieving original keys in random order vs in descending
+    # numerical order. On the one hand starting with high accessions
+    # will likely allow us to process rename chains from shorter to
+    # longer ones, thus, maximising the use of the cache; on the other
+    # there is the O(n log n) cost of sorting to take into account.
+    while ( defined( $old_to_new{$new} ) ) {
+      $new = $old_to_new{$new};
+    }
+
+    # With the latest value of $new no longer pointing to anything in
+    # %old_to_new, we have got two options: either we have finally
+    # reached an up-to-date entry number or the entry has ultimately
+    # been removed from the database. See if we have logged the
+    # removal, if we haven't add the synonyms - letting Ensembl figure
+    # out by itself to which of the three (two???) sources the
+    # relevant xrefs belong.
+    if ( !defined( $removed{$new} ) ) {
+      $xref_dba->add_to_syn_for_mult_sources( $new, \@sources, $old,
+                                          $species_id );
+      $counters{ 'synonyms' }++;
+    }
+  }
+
+  if ($verbose) {
+    print $counters{ $gene_source_id } . ' genemap and '
+      . $counters{ $morbid_source_id } . " phenotype MIM xrefs added\n"
+      . $counters{ 'synonyms' } . " synonyms (defined by MOVED TO) added\n"
+      . $counters{ 'removed' } . " entries removed\n";
+  }
+
+  return 0;
+} ## end sub run
+
+
+sub extract_ti {
+  my ( $input_record ) = @_;
+
+  my ( $ti )
+    = ( $input_record =~ m{
+                            [*]FIELD[*]\sTI\n  # The TI field spans from this tag until:
+                            (.+?)              # (important: NON-greedy match)
+                            \n?
+                            (?: [*]FIELD[*]    #  - the next field in same record, or
+                            | [*]THEEND[*]   #  - the end of input file, or
+                            | \z             #  - the end of current record
+                            )
+                        }msx );
+
+  return $ti;
+}
+
+
+sub parse_ti {
+  my ( $ti ) = @_;
+
+  # Remove line breaks, making sure we do not accidentally concatenate words
+  $ti =~ s{
+            (?:
+              ;;\n
+            | \n;;
+            )
+        }{;;}gmsx;
+  $ti =~ s{\n}{ }gmsx;
+
+  # Extract the 'type' and the whole description
+  my @captures = ( $ti =~ m{
+                             ([#%+*^]*)  # type of entry
+                             (\d+)       # accession number, same as in NO
+                             \s+         # normally just one space
+                             (.+)        # description of entry
+                         }msx );
+
+  return @captures;
+}
+
+
+
+1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/Mim2GeneParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/Mim2GeneParser.pm
@@ -1,0 +1,274 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Xref::Parser::Mim2GeneParser;
+
+# For non-destructive substitutions in regexps (/r flag)
+require 5.014_000;
+
+use strict;
+use warnings;
+
+use Carp;
+use List::Util;
+use Readonly;
+use Text::CSV;
+
+use parent qw( Bio::EnsEMBL::Xref::Parser );
+
+
+Readonly my $EXPECTED_NUMBER_OF_COLUMNS => 5;
+
+
+sub run {
+  my ( $self ) = @_;
+  my $general_source_id = $self->{source_id};
+  my $species_id        = $self->{species_id};
+  my $files             = $self->{files};
+  my $verbose           = $self->{verbose} // 0;
+  my $xref_dba          = $self->{xref_dba};
+
+  my $csv = Text::CSV->new({
+                            sep_char => "\t",
+                          })
+    || confess 'Failed to initialise CSV parser: ' . Text::CSV->error_diag();
+
+  my $filename = @{$files}[0];
+
+  my $m2g_io = $xref_dba->get_filehandle($filename);
+
+  my $mim_gene_source_id =
+    $xref_dba->get_source_id_for_source_name( 'MIM_GENE' );
+  my $mim_morbid_source_id =
+    $xref_dba->get_source_id_for_source_name( 'MIM_MORBID' );
+  my $entrez_source_id =
+    $xref_dba->get_source_id_for_source_name( 'EntrezGene' );
+
+  # This will be used to prevent insertion of duplicates
+  $xref_dba->get_dependent_mappings( $mim_gene_source_id );
+  $xref_dba->get_dependent_mappings( $mim_morbid_source_id );
+
+  # FIXME: should we abort if any of these comes back empty?
+  my (%mim_gene) =
+    %{ $xref_dba->get_valid_codes( "MIM_GENE", $species_id ) };
+  my (%mim_morbid) =
+    %{ $xref_dba->get_valid_codes( "MIM_MORBID", $species_id ) };
+  my (%entrez) =
+    %{ $xref_dba->get_valid_codes( "EntrezGene", $species_id ) };
+
+  # Initialise all counters to 0 so that we needn't handle possible undefs
+  # while printing the summary
+  my %counters = (
+                  'all_entries'                          => 0,
+                  'dependent_on_entrez'                  => 0,
+                  'direct_ensembl'                       => 0,
+                  'missed_master'                        => 0,
+                  'missed_omim'                          => 0,
+                );
+
+ RECORD:
+  while ( my $line = $csv->getline( $m2g_io ) ) {
+
+    my ( $is_comment, $is_header )
+      = ( $line->[0] =~ m{
+                           \A
+                           ([#])?
+                           \s*
+                           (MIM[ ]Number)?  # FIXME: this is an assumption regarding header contents.
+                                            # See if $line has split to the right number of columns instead?
+                       }msx );
+    if ( $is_comment ) {
+      if ( ( scalar @{ $line } == $EXPECTED_NUMBER_OF_COLUMNS )
+           && ( ! is_header_file_valid( $line ) ) ) {
+        confess "Malformed or unexpected header in Mim2Gene file '${filename}'";
+      }
+      next RECORD;
+    }
+
+    if ( scalar @{ $line } != $EXPECTED_NUMBER_OF_COLUMNS ) {
+      confess ' Line ' . $csv->record_number()
+        . " of input file '${filename}' has an incorrect number of columns";
+    }
+
+    # Do not modify the contents of @{$line}, only the output - hence the /r.
+    my ( $omim_acc, $type, $entrez_id, $hgnc_symbol, $ensembl_id )
+      = map { s{\s+\z}{}rmsx } @{ $line };
+
+    $counters{'all_entries'}++;
+
+    # No point in doing anything if we have no matching MIM xref...
+    if ( ( !defined $mim_gene{$omim_acc} ) &&
+         ( !defined $mim_morbid{$omim_acc} ) )
+    {
+      $counters{'missed_omim'}++;
+      next RECORD;
+    }
+
+    # ...or no Ensembl ID or EntrezGene xref to match it to
+    # FIXME: this number might be underestimated because it doesn't
+    # check if Ensembl IDs from the input file actually exist
+    if ( ( ! $ensembl_id )
+         && ( ( ! $entrez_id ) || ( ! defined $entrez{$entrez_id} ) ) ) {
+      $counters{'missed_master'}++;
+      next RECORD;
+    }
+
+    # An unknown type might indicate the change of input format,
+    # therefore make sure the user notices it. That said, do not
+    # bother we do not have an xref this entry would operate on anyway
+    # - which is why we only check this after the preceding two
+    # presence checks.
+    if ( ( $type ne 'gene')
+         && ( $type ne 'gene/phenotype' )
+         && ( $type ne 'predominantly phenotypes' )
+         && ( $type ne 'phenotype' ) ) {
+      confess "Unknown type $type for MIM Number '${omim_acc}' "
+        . "(${filename}:" . $csv->record_number() . ")";
+    }
+
+    # With all the checks taken care of, insert the mappings. We check
+    # both MIM_GENE and MIM_MORBID every time because some MIM entries
+    # can appear in both.
+    foreach my $mim_xref_id ( @{ $mim_gene{$omim_acc} } ) {
+      $self->process_xref_entry({
+        'mim_xref_id'      => $mim_xref_id,
+        'mim_source_id'    => $mim_gene_source_id,
+        'ensembl_id'       => $ensembl_id,
+        'entrez_xrefs'     => $entrez{$entrez_id},
+        'entrez_source_id' => $entrez_source_id,
+        'counters'         => \%counters,
+      });
+    }
+    foreach my $mim_xref_id ( @{ $mim_morbid{$omim_acc} } ) {
+      $self->process_xref_entry({
+        'mim_xref_id'      => $mim_xref_id,
+        'mim_source_id'    => $mim_morbid_source_id,
+        'ensembl_id'       => $ensembl_id,
+        'entrez_xrefs'     => $entrez{$entrez_id},
+        'entrez_source_id' => $entrez_source_id,
+        'counters'         => \%counters,
+      });
+    }
+
+  } ## end record loop
+
+  $csv->eof || confess 'Error parsing CSV: ' . $csv->error_diag();
+  $m2g_io->close();
+
+  if ( $verbose ) {
+    print 'Processed ' . $counters{'all_entries'} . " entries. Out of those\n"
+      . "\t" . $counters{'missed_omim'} . " had missing OMIM entries,\n"
+      . "\t" . $counters{'direct_ensembl'} . " were direct gene xrefs,\n"
+      . "\t" . $counters{'dependent_on_entrez'} . " were dependent EntrezGene xrefs,\n"
+      . "\t" . $counters{'missed_master'} . " had missing master entries.\n";
+  }
+
+  return 0;
+} ## end sub run
+
+
+=head2 is_file_header_valid
+
+  Arg [1]    : String file header line
+  Example    : if (!is_file_header_valid($header_line)) {
+                 confess 'Bad header';
+               }
+  Description: Verifies if the header of a Mim2Gene file follows expected
+               syntax.
+               We do not check the number of columns because that is what
+               we use to *detect* the header in the first place.
+  Return type: boolean
+  Exceptions : none
+  Caller     : internal
+  Status     : Stable
+
+=cut
+
+sub is_header_file_valid {
+  my ( $header ) = @_;
+
+  my @fields_ok;
+
+  Readonly my @field_patterns
+    => (
+        qr{ \A [#]? \s* MIM[ ]Number }msx,
+        qr{ MIM[ ]Entry[ ]Type }msx,
+        qr{ Entrez[ ]Gene[ ]ID }msx,
+        qr{ Approved[ ]Gene[ ]Symbol }msx,
+        qr{ Ensembl[ ]Gene[ ]ID }msx,
+      );
+
+  my $header_field;
+  foreach my $pattern (@field_patterns) {
+    $header_field = shift @{ $header };
+    # Make sure we run the regex match in scalar context
+    push @fields_ok, scalar ( $header_field =~ m{ $pattern }msx );
+  }
+
+  # All fields must have matched
+  return List::Util::all { $_ } @fields_ok;
+}
+
+
+=head2 process_xref_entry
+
+  Arg [1]    : HashRef list of named arguments: FIXME
+  Example    : $self->process_xref_entry({...});
+  Description: Wrapper around the most frequently repeated bit of
+               run(): if $ensembl_id is defined insert a direct MIM
+               xref, otherwise loop over the list of matching
+               EntrezGene xrefs and insert dependent MIM xrefs.
+               In either case increment the correct counter.
+  Return type: none
+  Exceptions : none
+  Caller     : internal
+  Status     : Stable
+
+=cut
+
+sub process_xref_entry {
+  my ( $self, $arg_ref ) = @_;
+
+  my $xref_dba = $self->{xref_dba};
+
+  if ( $arg_ref->{'ensembl_id'} ) {
+    $arg_ref->{'counters'}->{'direct_ensembl'}++;
+    $xref_dba->add_direct_xref( $arg_ref->{'mim_xref_id'},
+                            $arg_ref->{'ensembl_id'},
+                            'gene',
+                            undef,
+                            1
+                         );
+  }
+  else {
+    foreach my $ent_id ( @{ $arg_ref->{'entrez_xrefs'} } ) {
+      $arg_ref->{'counters'}->{'dependent_on_entrez'}++;
+      $xref_dba->add_dependent_xref_maponly( $arg_ref->{'mim_xref_id'},
+                                         $arg_ref->{'mim_source_id'},
+                                         $ent_id,
+                                         $arg_ref->{'entrez_source_id'},
+                                         1
+                                      );
+    }
+  }
+
+  return;
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
@@ -1,0 +1,185 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+
+package Bio::EnsEMBL::Xref::Parser::UniProtParser;
+
+use strict;
+use warnings;
+
+use Carp;
+use Module::Load;
+use Readonly;
+
+use parent qw( Bio::EnsEMBL::Xref::Parser );
+
+
+Readonly my $DEFAULT_LOADER_BATCH_SIZE => 1000;
+
+Readonly my %source_name_for_section => (
+                                         'Swiss-Prot' => 'Uniprot/SWISSPROT',
+                                         'TrEMBL'     => 'Uniprot/SPTREMBL',
+                                       );
+
+
+sub run {
+  my ( $self ) = @_;
+
+  my $general_source_id = $self->{source_id};
+  my $species_id        = $self->{species_id};
+  my $species_name      = $self->{species};
+  my $files             = $self->{files};
+  my $release_file      = $self->{rel_file};
+  my $verbose           = $self->{verbose} // 0;
+  my $xref_dba          = $self->{xref_dba};
+
+  my $loader_batch_size
+    = $self->{loader_batch_size} // $DEFAULT_LOADER_BATCH_SIZE;
+
+  # Try to control where ETL modules can come from, just in case
+  # someone does something really weird with configuration options.
+  my $extractor_class   = 'Bio::EnsEMBL::Xref::Parser::UniProtParser::';
+  my $transformer_class = 'Bio::EnsEMBL::Xref::Parser::UniProtParser::';
+  my $loader_class      = 'Bio::EnsEMBL::Xref::Parser::UniProtParser::';
+
+  $extractor_class   .= $self->{extractor_class}   // 'Extractor';
+  $transformer_class .= $self->{transformer_class} // 'Transformer';
+  $loader_class      .= $self->{loader_class}      // 'Loader';
+
+  load $extractor_class;
+  load $transformer_class;
+  load $loader_class;
+
+  my $extractor = $extractor_class->new({
+    'file_names' => $files,
+    'species_id' => $species_id,
+    'xref_dba'   => $xref_dba,
+  });
+  my $transformer = $transformer_class->new({
+    'species_id' => $species_id,
+    'xref_dba'   => $xref_dba,
+  });
+  my $loader = $loader_class->new({
+    'batch_size' => $loader_batch_size,
+    'xref_dba'   => $xref_dba,
+  });
+
+  # Generate a map of existing dependent-xref links, which will be
+  # used to prevent insertion of duplicates
+  my $source_id_map = $transformer->get_source_id_map();
+  while ( my ( $section, $pri_ref ) = each %{ $source_id_map } ) {
+    while ( my ( $priority, $source_id ) = each %{ $pri_ref } ) {
+
+      if ( $priority ne 'direct' ) {
+        $loader->prepare_source_for_dependent_xrefs( $source_id );
+      }
+
+      # Seeing as we are already looping over all sources.
+      # FIXME: do we really care about the file name here?
+      if ( $verbose ) {
+        print "$section $priority source id for $files->[0]: $source_id\n";
+      }
+
+    }
+  }
+
+ RECORD:
+  while ( $extractor->get_uniprot_record() ) {
+
+    my $extracted_record = $extractor->extract();
+    if ( $extracted_record eq 'SKIP' ) {
+      next RECORD;
+    }
+
+    my $transformed_data
+      = $transformer->transform( $extracted_record );
+
+    $loader->load( $transformed_data );
+
+  }
+
+  $extractor->finish();
+  $transformer->finish();
+  $loader->finish();
+
+  # Extract release numbers from the release file, if provided
+  if ( defined $release_file ) {
+    my $release_numbers = $self->_get_release_numbers_from_file( $release_file,
+                                                                 $verbose );
+    $self->_set_release_numbers_on_uniprot_sources( $source_id_map,
+                                                    $release_numbers );
+  }
+
+  return 0;
+}
+
+
+# Extract Swiss-Prot and TrEMBL release info from the release file
+sub _get_release_numbers_from_file {
+  my ( $self, $release_file_name, $verbose ) = @_;
+
+  my $xref_dba = $self->{xref_dba};
+
+  my $release_io = $xref_dba->get_filehandle( $release_file_name );
+  my $release_numbers = {};
+
+  while ( my $line = $release_io->getline() ) {
+    my ( $section, $release )
+      = ( $line =~ m{
+                      \A
+                      UniProtKB/
+                      (
+                        Swiss-Prot
+                      |
+                        TrEMBL
+                      )
+                      \s+
+                      Release
+                      \s+
+                      ( [^\n]+ )
+                  }msx );
+    if ( defined $section ) {
+      $release_numbers->{ $source_name_for_section{$section} } = $release;
+      if ( $verbose ) {
+        print "$section release is '$release'\n";
+      }
+    }
+  }
+
+  $release_io->close();
+
+  return $release_numbers;
+}
+
+sub _set_release_numbers_on_uniprot_sources {
+  my ( $self, $source_id_map, $release_numbers ) = @_;
+
+  my $xref_dba = $self->{xref_dba};
+
+  foreach my $source ( keys %{ $source_id_map } ) {
+    # Priority names are not important here, we only need source IDs
+    foreach my $source_id ( values %{ $source_id_map->{$source} } ) {
+      $xref_dba->set_release( $source_id, $release_numbers->{$source} );
+    }
+  }
+
+  return;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
@@ -30,7 +30,8 @@ use Readonly;
 use parent qw( Bio::EnsEMBL::Xref::Parser );
 
 
-Readonly my $DEFAULT_LOADER_BATCH_SIZE => 1000;
+Readonly my $DEFAULT_LOADER_BATCH_SIZE         => 1000;
+Readonly my $DEFAULT_LOADER_CHECKPOINT_SECONDS => 300;
 
 Readonly my %source_name_for_section => (
                                          'Swiss-Prot' => 'Uniprot/SWISSPROT',
@@ -51,6 +52,8 @@ sub run {
 
   my $loader_batch_size
     = $self->{loader_batch_size} // $DEFAULT_LOADER_BATCH_SIZE;
+  my $loader_checkpoint_seconds
+    = $self->{loader_checkpoint_seconds} // $DEFAULT_LOADER_CHECKPOINT_SECONDS;
 
   # Try to control where ETL modules can come from, just in case
   # someone does something really weird with configuration options.
@@ -76,8 +79,9 @@ sub run {
     'xref_dba'   => $xref_dba,
   });
   my $loader = $loader_class->new({
-    'batch_size' => $loader_batch_size,
-    'xref_dba'   => $xref_dba,
+    'batch_size'         => $loader_batch_size,
+    'checkpoint_seconds' => $loader_checkpoint_seconds,
+    'xref_dba'           => $xref_dba,
   });
 
   # Generate a map of existing dependent-xref links, which will be

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Extractor.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Extractor.pm
@@ -1,0 +1,789 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+
+package Bio::EnsEMBL::Xref::Parser::UniProtParser::Extractor;
+
+use strict;
+use warnings;
+
+# For non-destructive substitutions in regexps (/r flag)
+require 5.014_000;
+
+use Carp;
+use List::Util;
+use Readonly;
+use charnames ':full';
+
+
+# While processing DR fields i.e. crossreferences, used to match the
+# syntax attaching a crossreference to a specific isoform. Declares
+# ONE capture group, the isoform identifier.
+# Use named sequences for square brackets to avoid excessive
+# escaping as well as for better readability.
+Readonly my $QR_DR_ISOFORM_FIELD_PATTERN
+  => qr{
+         \s*
+         \N{LEFT SQUARE BRACKET}
+         \s*
+         ( [^\N{RIGHT SQUARE BRACKET}]+ )
+         \s*
+         \N{RIGHT SQUARE BRACKET}
+         \s*
+     }msx;
+
+# While processing ID fields, used to confirm that the status of an
+# entry matches an expected value. Declares NO capture groups.
+Readonly my $QR_ID_STATUS_FIELD
+  => qr{
+         (?: Unreviewed )
+       | (?: Reviewed )
+     }msx;
+
+# While processing OX fields i.e. taxonomy cross-references, used to
+# extract both the taxon code and the database qualifier. Declares TWO
+# capture groups: the database qualifier, and the taxonomic code.
+Readonly my $QR_OX_TAXON_DB_ENTRY
+  => qr{
+         # Database qualifier. Chances are the list of
+         # allowed characters will change should DBs
+         # other than NCBI ever become supported here.
+         ( [A-Za-z_]+ )
+
+         \s*  # just in case
+         =
+         \s*  # same
+
+         # Taxon ID. This is almost certainly NCBI-specific.
+         ( [0-9]+ )
+     }msx;
+
+# While processing OX or DE fields, i.e. taxonomy cross-references or
+# descriptions, allows accounting for the fact some entries might be
+# followed by evidence codes. As of October 2018, this syntax is not
+# declared in UniProt-KB User Manual yet frequently encountered in
+# data files.  Use named sequences for curly brackets to avoid
+# excessive escaping as well as for better readability.
+Readonly my $QR_OX_DE_EVIDENCE_CODE_LIST
+  => qr{
+         \N{LEFT CURLY BRACKET}
+         \s*
+         [^\N{RIGHT CURLY BRACKET}]+
+         \s*
+         \N{RIGHT CURLY BRACKET}
+         \s*
+     }msx;
+
+# To save memory and processing time, when we process a record we only
+# load into memory the fields we need. Conversely, the same list can
+# later on be used that we have indeed encountered all the mandatory
+# fields.
+# Note that care must be taken when adding new prefixes to this list
+# because some of them - for instance the Rx family of fields,
+# describing publications - are not compatible with the current way of
+# processing.
+# Syntax: 1 is mandatory field, 0 - an optional one
+Readonly my %prefixes_of_interest
+  => (
+      'ID'  => 1,
+      'AC'  => 1,
+      'DE'  => 1,
+      'GN'  => 0,
+      'OX'  => 1,
+      'DR'  => 0,
+      'PE'  => 1,
+      'RG'  => 0,
+      'SQ'  => 1,
+      q{  } => 1,
+    );
+
+# Syntax: 0 for database qualifiers to be ignored, otherwise a
+# reference to a function translating taxon codes from the given
+# database into Ensembl taxonomy_ids.
+Readonly my %taxonomy_ids_from_taxdb_codes
+  => (
+      # NCBI taxon codes and Ensembl taxonomy IDs are identical
+      'NCBI_TaxID' => sub { return $_[0]; },
+    );
+
+
+
+# FIXME: at the moment the extractor only handles one input file at a
+# time for backwards compatibility with the old UniProtParser, that
+# said there is no reason for it not to be able to handle multiple
+# files. Should we want to support this, we should stop opening the
+# filehandle in the constructor because it would no longer be a fixed
+# property of the object.
+sub new {
+  my ( $proto, $arg_ref ) = @_;
+  my $file_names = $arg_ref->{'file_names'};
+  my $species_id = $arg_ref->{'species_id'};
+  my $xref_dba   = $arg_ref->{'xref_dba'};
+
+  my $filename = $file_names->[0];
+  my $filehandle = $xref_dba->get_filehandle( $filename );
+
+  # Keep the file name for possible debugging purposes, unless we can
+  # somehow retrieve it from _io_handle
+  my $self = {
+              'input_name' => $filename,
+              '_io_handle' => $filehandle,
+              'maps'       => {},
+              'species_id' => $species_id,
+              'xref_dba'   => $xref_dba,
+            };
+  my $class = ref $proto || $proto;
+  bless $self, $class;
+
+  $self->_load_maps();
+
+  return $self;
+}
+
+
+sub DESTROY {
+  my ( $self ) = @_;
+
+  $self->finish();
+
+  return;
+}
+
+
+sub close_input {
+  my ( $self ) = @_;
+
+  $self->{'_io_handle'}->close();
+
+  return;
+}
+
+
+sub extract {
+  my ( $self ) = @_;
+
+  $self->_record_has_all_needed_fields();
+
+  my $accession_numbers = $self->_get_accession_numbers();
+
+  # Only proceed if at least one taxon code in the entry maps
+  # to the current species ID, and skip unreviewed entries.
+  if ( ( ! $self->_taxon_codes_match_species_id() )
+       || ( $self->_entry_is_unreviewed( $accession_numbers ) ) ) {
+    return 'SKIP';
+  }
+
+  my $entry_object
+    = {
+       'accession_numbers' => $accession_numbers,
+       'citation_groups'   => $self->_get_citation_groups(),
+       'crossreferences'   => $self->_get_database_crossreferences(),
+       'description'       => $self->_get_description() // undef,
+       'gene_names'        => $self->_get_gene_names(),
+       'quality'           => $self->_get_quality(),
+       'sequence'          => $self->_get_sequence() // undef,
+     };
+
+  return $entry_object;
+}
+
+
+sub finish {
+  my ( $self ) = @_;
+
+  $self->close_input();
+
+  return;
+}
+
+
+sub get_uniprot_record {
+  my ( $self ) = @_;
+
+  my $io = $self->{'_io_handle'};
+  my $uniprot_record = {};
+
+ INPUT_LINE:
+  while ( my $file_line = $io->getline() ) {
+    chomp $file_line;
+
+    my ( $prefix, $content )
+      = ( $file_line =~ m{ \A
+                           ([A-Z /]{2})  # prefix
+                           (?:
+                             \s{3}       # leading spaces are important in e.g. DE, FT
+                             (.+)        # content
+                           )?            # end-of-record line will not have any of this
+                           \z
+                       }msx );
+    if ( ! defined $prefix ) {
+      confess "Malformed prefix in line:\n\t${file_line}";
+    }
+
+    if ( $prefix eq q{//} ) {
+      # End of record, return what we have got so far
+      $self->{'record'} = $uniprot_record;
+      return 1;
+    }
+
+    # Do not waste time and memory on fields we do not need
+    if ( ! exists $prefixes_of_interest{$prefix} ) {
+      next INPUT_LINE;
+    }
+
+    if ( ! exists $uniprot_record->{$prefix} ) {
+      $uniprot_record->{$prefix} = [];
+    }
+    push @{ $uniprot_record->{$prefix} }, $content;
+
+  }
+
+  # If we began parsing fields but have never reached the //,
+  # something is very wrong
+  if ( scalar keys %{ $uniprot_record } > 0 ) {
+    confess 'Incomplete input record';
+  }
+
+  # EOF
+  return 0;
+}
+
+
+sub _load_maps {
+  my ( $self ) = @_;
+
+  my $xref_dba = $self->{'xref_dba'};
+
+  my $taxonomy_ids_for_species
+    = $xref_dba->get_taxonomy_from_species_id( $self->{'species_id'} );
+  # If the map is empty, something is wrong
+  if ( scalar keys %{ $taxonomy_ids_for_species } == 0 ) {
+    confess "Got zero taxonomy_ids for species_id '"
+      . $self->{'species_id'} . q{'};
+  }
+  $self->{'maps'}->{'taxonomy_ids_for_species'}
+    = $taxonomy_ids_for_species;
+
+  return;
+}
+
+
+
+# Returns true if the current record describes an entry tagged as
+# unreviewed, false otherwise.
+sub _entry_is_unreviewed {
+  my ( $self, $accession_numbers ) = @_;
+
+  # This is the way the old UniProtParser identified unreviewed
+  # entries. FIXME: is this still a thing? As of October 2018 there
+  # are NO such entries in either the first ~1000 lines of the TrEMBL
+  # file or anywhere in the SwissProt one.
+  if ( lc( $accession_numbers->[0] ) eq 'unreviewed' ) {
+    return 1;
+  }
+
+  return 0;
+}
+
+
+# Parse the AC fields of the current record and produce a list of
+# UniProt accession numbers. The list will reflect the order in which
+# accession numbers appeared in the record, which as of October 2018
+# is: primary accession number first, then all the secondary ones in
+# alphanumerical order.
+sub _get_accession_numbers {
+  my ( $self ) = @_;
+
+  my $ac_fields = $self->{'record'}->{'AC'};
+  my @numbers
+    = split( qr{\s* ; \s*}msx, join( q{}, @{ $ac_fields } ) );
+  # FIXME: we should probably make this persist until a new record has
+  # been loaded
+
+  return \@numbers;
+}
+
+
+# Parse the RG fields of the current record, if any, and produce a
+# list of names of groups which cite this protein.
+# Warning: this is intentionally simplistic (for example it makes no
+# attempt to associate group names for specific reference numbers) and
+# will NOT work properly if more detailed citation information is
+# required! If you need that, you will have to implement comprehensive
+# processing of different Rx lines.
+sub _get_citation_groups {
+  my ( $self ) = @_;
+
+  my $rg_fields = $self->{'record'}->{'RG'};
+
+  # RG is an optional field
+  if ( ! defined $rg_fields ) {
+    return [];
+  }
+
+  # FIXME: we should probably make this persist until a new record has
+  # been loaded
+  my @citation_groups = split( qr{ \s*;\s* }msx,
+                               join( q{}, @{ $rg_fields } ) );
+
+  return \@citation_groups;
+}
+
+
+# Parse the CC fields of the current record and produce a hash mapping
+# comments to their respective topics. Optionally, the returned data
+# can be restricted to specific topics.
+# FIXME: not used at present, which could result in it no longer
+# working by the time it has been reenabled. Either ensure it is
+# tested or remove it.
+sub _get_comments {
+  my ( $self, @topics_to_return ) = @_;
+
+  my $cc_fields = $self->{'record'}->{'CC'};
+
+  # CC is an optional field
+  if ( ! defined $cc_fields ) {
+    return {};
+  }
+
+  # FIXME: we should probably make this persist until a new record has
+  # been loaded
+  my %comments_by_topic;
+
+  # FIXME: get rid of extra whitespace from the beginning of
+  # continuation lines
+  my @topic_lines = split( qr{\s* -!- \s*}msx,
+                           join( q{ }, @{ $cc_fields } )
+                        );
+  foreach my $line ( @topic_lines ) {
+
+    my ($topic, $content)
+      = ( $line =~ m{
+                      \A
+
+                      # Topic name: one or more words in ALL CAPS
+                      ( [A-Z ]+ )
+
+                      # Separator
+                      \s*
+                      :
+                      \s*
+
+                      # Everything else is content
+                      ( .+ )
+                  }msx );
+
+    # This will bypass the first empty line of @topic_lines
+    if ( defined $topic ) {
+      # FIXME: can a record have multiple entries with the same topic???
+      $comments_by_topic{$topic} = $content;
+    }
+  }
+
+  # If we haven't been asked for specific topics, return all comments.
+  if ( scalar @topics_to_return == 0 ) {
+    return \%comments_by_topic;
+  }
+
+  my %comments_of_interest;
+  foreach my $topic ( @topics_to_return ) {
+    $comments_of_interest{$topic} = $comments_by_topic{$topic};
+  }
+  return \%comments_of_interest;
+}
+
+
+# Parse the DR fields of the current record, break them into
+# constituent parts and produce a list (or to be precise, a hash of
+# arrayrefs) of database cross-references grouped by reference.
+sub _get_database_crossreferences {
+  my ( $self ) = @_;
+
+  my $dr_fields = $self->{'record'}->{'DR'};
+
+  # DR is an optional field
+  if ( ! defined $dr_fields ) {
+    return [];
+  }
+
+  # FIXME: we should probably make this persist until a new record has
+  # been loaded
+  my $crossreferences = {};
+
+  foreach my $dr_line ( @{ $dr_fields } ) {
+    my ( $res_abbrev, $res_id, @opts ) = split( qr{ ;\s* }msx, $dr_line);
+
+    my ( $last_opt, $isoform )
+      = ( $opts[-1] =~ m{
+                          ( .+ )  # will grab all dots but the last one
+                          [.]
+                          (?:
+                            $QR_DR_ISOFORM_FIELD_PATTERN
+                          )?
+                          \z
+                      }msx );
+    if ( ! defined $last_opt ) {
+      confess "Malformed final-option match in:\n\t$dr_line";
+    }
+
+    # At the very least, strips the trailing dot
+    $opts[-1] = $last_opt;
+
+    my $crossref
+      = {
+         'id'            => $res_id,
+         'optional_info' => \@opts,
+       };
+    if ( defined $isoform ) {
+      $crossref->{'target_isoform'} = $isoform;
+    }
+
+    # There CAN be multiple cross-references to a database
+    push @{ $crossreferences->{$res_abbrev} }, $crossref;
+  }
+
+  return $crossreferences;
+}
+
+
+# Parse the DE fields of the current record and produce a description
+# string compatible with the output of the old UniProtParser, namely:
+#  - the description begins with a semicolon-separated list of
+#    top-level names (i.e. ones not belonging to a Contains or
+#    Includes section), in the order they appear in the record;
+#  - this list is followed by a space and a space-separated list of
+#    names from Contains and Includes sections, again in the order
+#    they appear in the record;
+#  - we process both RecNames and SubNames, and both types are
+#    considered of equal priority (i.e. ultimately it is their order
+#    that matters);
+#  - in either case we only consider full names;
+#  - evidence codes, PubMed references etc. are discarded.
+# Note that unlike most field parsers implemented so far, this one
+# does NOT attempt to fully process the syntax of DE fields; this is
+# in order to avoid messing with whitespace-defined context only to
+# discard most of the field data anyway. Keep this in mind should you
+# want to extend the parsing to e.g. extract EC numbers, in which case
+# you will likely have to implement a full parser.
+sub _get_description {
+  my ( $self ) = @_;
+
+  my $de_fields = $self->{'record'}->{'DE'};
+
+  my @names;
+  my @subdescs;
+
+  foreach my $line ( @{ $de_fields } ) {
+    my ( $indent, $content )
+      = ( $line =~ m{
+                      \A
+                      ( \s* )  # To detect sub-entries such as Includes:
+                      (?:
+                        RecName | SubName
+                      )
+                      :
+                      \s*
+                      Full=
+                      ( [^;]+ )
+                  }msx );
+    if ( defined $indent ) {
+      # Strip evidence codes, if any. This could in principle be
+      # integrated into the match but it makes the regex rather more
+      # complex.
+      $content =~ s{
+                     \s*
+                     $QR_OX_DE_EVIDENCE_CODE_LIST
+                     \z
+                 }{}msx;
+
+      if ( $indent eq q{} ) {
+        push @names, $content;
+      }
+      else {
+        push @subdescs, $content;
+      }
+    }
+  }
+
+  my $description
+    = join( q{ }, (
+                   join( q{;}, @names ),
+                   @subdescs
+                 ) );
+  # Make sure we do not return an empty string
+  if ( length( $description ) > 0 ) {
+    return $description;
+  }
+  return;
+}
+
+
+# Parse the GN fields of the current record and produce a structured
+# list of names of genes coding the protein sequence in question.
+sub _get_gene_names {
+  my ( $self ) = @_;
+
+  my $gn_fields = $self->{'record'}->{'GN'};
+
+  # GN is an optional field
+  if ( ! defined $gn_fields ) {
+    return [];
+  }
+
+  my @gn_text_entries;
+
+  # Gene-name entries can span multiple GN names but we cannot simply
+  # concatenate them all because there can be multiple gene names per
+  # record. In order to merge data correctly we must look for the
+  # name-separator line.
+  my $current_entry = q{};
+  foreach my $line ( @{ $gn_fields } ) {
+    # This is what the separator line looks like
+    if ( $line eq 'and' ) {
+      push @gn_text_entries, $current_entry;
+      $current_entry = q{};
+    }
+    else {
+      # No need for extra spaces here
+      $current_entry .= $line;
+    }
+  }
+  # Make sure the last entry makes it in as well
+  push @gn_text_entries, $current_entry;
+
+  my $gene_names = [];
+  foreach my $entry ( @gn_text_entries ) {
+    my $parsed_entry = {};
+
+    my @entry_captures = ( $entry =~ m{
+                                        \s*
+                                        ( [^=]+ )
+                                        \s*
+                                        =
+                                        \s*
+                                        ( [^;]+ )
+                                        \s*
+                                        ;
+                                    }gmsx );
+
+    while ( my ( $key, $value ) = splice( @entry_captures, 0, 2 ) ) {
+      my @split_value = split( qr{ \s*,\s* }msx, $value );
+
+      $parsed_entry->{$key}
+        = ( $key eq 'Name' ) ? $value : \@split_value;
+    }
+
+    # UniProt-KB User Manual states a "Synonyms" token can only be
+    # present if there is a "Name" token.
+    if ( ( exists $parsed_entry->{'Synonyms'} )
+         && ( ! exists $parsed_entry->{'Name'} ) ) {
+      confess "Malformed input: found 'Synonyms' but no 'Name' in:\n\t$entry";
+    }
+
+    push @{ $gene_names }, $parsed_entry;
+  }
+
+  return $gene_names;
+}
+
+
+# Obtain quality information for the current record. This consists of
+# two parts: status (i.e. whether the entry has been reviewed or not)
+# from the ID line and evidence level from the PE line.
+sub _get_quality {
+  my ( $self ) = @_;
+
+  # There is only one ID line
+  my $id_line = $self->{'record'}->{'ID'}->[0];
+  my ( $entry_status )
+    = ( $id_line =~ m{
+                       \A
+
+                       # UniProt name
+                       [0-9A-Z_]+
+
+                       \s+
+
+                       ( $QR_ID_STATUS_FIELD )
+                       \s*
+                       ;
+                   }msx );
+  if ( ! defined $entry_status ) {
+    confess "Invalid entry status in:\n\t$id_line";
+  }
+
+  # Likewise, there is only one PE line
+  my $pe_line = $self->{'record'}->{'PE'}->[0];
+  my ( $evidence_level )
+    = ( $pe_line =~ m{
+                       \A
+
+                       ( [1-5] )
+                       \s*
+                       :
+                   }msx );
+  if ( ! defined $evidence_level ) {
+    confess "Invalid protein evidence level in:\n\t$pe_line";
+  }
+
+  return {
+          'status'         => $entry_status,
+          'evidence_level' => $evidence_level,
+        };
+}
+
+
+# Parse the sequence ('  ') fields of the current record and produce
+# its polypeptide sequence. as a continuous string i.e. without
+# decorative whitespace.
+sub _get_sequence {
+  my ( $self ) = @_;
+
+  my $sequence_fields = $self->{'record'}->{ q{  } };
+
+  # Concatenate the sequence into a single continuous string. We do
+  # not expect to see more than whitespace at a time so instead of
+  # trying to match as long a string of them as possible in order to
+  # minimise the number of independent substitutions, we always match
+  # on one in order to avoid unnecessary backtracking.
+  # Note that we use non-destructive substitution.
+  my $sequence = ( join( q{}, @{ $sequence_fields } ) =~ s{ \s }{}grmsx );
+
+  # We could in principle directly return substitution result but then
+  # we would have to make sure we always call get_sequence() in scalar
+  # context. Safer to simply return a scalar instead.
+  return $sequence;
+}
+
+
+
+# Parse the OX field of the current record and produce a list of
+# database_qualifier/taxon_code pairs.
+sub _get_taxon_codes {
+  my ( $self ) = @_;
+
+  # There is only one OX line
+  my $ox_line = $self->{'record'}->{'OX'}->[0];
+
+  # On the one hand, according to UniProt-KB User Manual from October
+  # 2018 there should only be a single taxon code per OX line and the
+  # current SwissProt data file doesn't contain any records which
+  # violate this. On the other hand we haven't checked this in the
+  # TrEMBL file because of its size and the old UniProtParser did have
+  # support for synonyms (albeit using different syntax -
+  # "db=id1, id2, ...;" rather than "db1=id1; db2=id2; ...").
+  # The code below assumes there might be multiple entries present, if
+  # you want to force it to only ever look for one simply drop the /g
+  # modifier from the regex match.
+
+  my @ox_captures
+    = ( $ox_line =~ m{
+                       $QR_OX_TAXON_DB_ENTRY
+                       \s*
+
+                       # Optional things (e.g. evidence codes) we do
+                       # not need now but must parse on the off chance
+                       # someone decides e.g. that curly braces
+                       # constitute quotes so it is okay to have a
+                       # semicolon between them
+                       (?:
+                         $QR_OX_DE_EVIDENCE_CODE_LIST
+                         | [^;]+
+                       )?
+
+                       # End of record
+                       ;
+                   }gmsx );
+
+  my @extracted_taxon_codes;
+
+  # Reminder: if you change the number of capture groups above
+  # remember to adapt both the variable list *and* the third argument
+  # to splice().
+ TAXON_ENTRY:
+  while ( my ( $db_qualifier, $taxon_code ) = splice( @ox_captures, 0, 2 ) ) {
+
+    if ( ( ! defined $db_qualifier )
+         || ( ! exists $taxonomy_ids_from_taxdb_codes{$db_qualifier} ) ) {
+      # Abort on malformed or new database qualifiers
+      confess "Cannot use taxon-DB qualifier '${db_qualifier}'";
+    }
+    elsif ( ! $taxonomy_ids_from_taxdb_codes{$db_qualifier} ) {
+      # Known but of no interest. Ignore it.
+      next TAXON_ENTRY;
+    }
+
+    if ( ! defined $taxon_code ) {
+      confess "Failed to extract taxon code from:\n\t${ox_line}";
+    }
+
+    push @extracted_taxon_codes, {
+                                  'db_qualifier' => $db_qualifier,
+                                  'taxon_code'     => $taxon_code,
+                                };
+
+  }
+
+  return \@extracted_taxon_codes;
+}
+
+
+# Translate extracted taxon codes into Ensembl taxonomy IDs, then
+# check if any of them correspond the current species ID.
+sub _taxon_codes_match_species_id {
+  my ( $self ) = @_;
+
+  my $taxon_codes = $self->_get_taxon_codes();
+  my $tid4s_map = $self->{'maps'}->{'taxonomy_ids_for_species'};
+
+  my @taxonomy_ids;
+  foreach my $taxon ( @{ $taxon_codes } ) {
+    my $code_mapper
+      = $taxonomy_ids_from_taxdb_codes{ $taxon->{'db_qualifier'} };
+    push @taxonomy_ids, $code_mapper->( $taxon->{'taxon_code'} );
+  }
+
+  foreach my $taxonomy_id ( @taxonomy_ids ) {
+    if ( exists $tid4s_map->{$taxonomy_id} ) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+
+sub _record_has_all_needed_fields {
+  my ( $self ) = @_;
+
+  # Only check mandatory fields
+  my @needed_fields
+    = grep { $prefixes_of_interest{$_} } keys %prefixes_of_interest;
+
+  my $has_all
+    = List::Util::all { exists $self->{'record'}->{$_} } @needed_fields;
+  if ( ! $has_all ) {
+    confess 'One or more required fields missing in record';
+ }
+
+  return;
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Loader.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Loader.pm
@@ -1,0 +1,125 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+
+package Bio::EnsEMBL::Xref::Parser::UniProtParser::Loader;
+
+use strict;
+use warnings;
+
+use Carp;
+
+
+sub new {
+  my ( $proto, $arg_ref ) = @_;
+
+  my $self = {
+              'batch_size' => $arg_ref->{'batch_size'} // 1,
+              'xref_dba'   => $arg_ref->{'xref_dba'},
+            };
+  my $class = ref $proto || $proto;
+  bless $self, $class;
+  $self->_clear_send_buffer();
+
+  return $self;
+}
+
+
+sub DESTROY {
+  my ( $self ) = @_;
+
+  $self->finish();
+
+  return;
+}
+
+
+sub finish {
+  my ( $self ) = @_;
+
+  $self->flush();
+
+  return;
+}
+
+
+sub flush {
+  my ( $self ) = @_;
+
+  my $xref_dba = $self->{'xref_dba'};
+
+  if ( ! $xref_dba->upload_xref_object_graphs( $self->{'send_buffer'} ) ) {
+    confess 'Failed to upload xref object graphs. Check for errors on STDOUT';
+  }
+
+  $self->_clear_send_buffer();
+
+  return;
+}
+
+
+sub load {
+  my ( $self, $transformed_data ) = @_;
+
+  if ( ! defined $transformed_data ) {
+    return;
+  }
+
+  $self->_add_to_send_buffer( $transformed_data );
+
+  if ( $self->{'send_backlog'} >= $self->{'batch_size'} ) {
+    $self->flush();
+  }
+
+  return;
+}
+
+
+sub prepare_source_for_dependent_xrefs {
+  my ( $self, $source_id ) = @_;
+
+  my $xref_dba = $self->{'xref_dba'};
+
+  $xref_dba->get_dependent_mappings( $source_id );
+
+  return;
+}
+
+
+sub _add_to_send_buffer {
+  my ( $self, $entry ) = @_;
+
+  push @{ $self->{'send_buffer'} }, $entry;
+  $self->{'send_backlog'}++;
+
+  return;
+}
+
+
+sub _clear_send_buffer {
+  my ( $self ) = @_;
+
+  $self->{'send_buffer'}  = [];
+  $self->{'send_backlog'} = 0;
+
+  return;
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Transformer.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Transformer.pm
@@ -1,0 +1,423 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+
+package Bio::EnsEMBL::Xref::Parser::UniProtParser::Transformer;
+
+use strict;
+use warnings;
+
+use Carp;
+use Readonly;
+
+
+Readonly my $PROTEIN_ID_SOURCE_NAME => 'protein_id';
+Readonly my $UNIPROT_GN_SOURCE_NAME => 'Uniprot_gn';
+
+Readonly my %whitelisted_crossreference_sources
+  => (
+      'ChEMBL'                => 1,
+      'EMBL'                  => 1,
+      'Ensembl'               => 1,
+      'MEROPS'                => 1,
+      'PDB'                   => 1,
+      $PROTEIN_ID_SOURCE_NAME => 1,
+      $UNIPROT_GN_SOURCE_NAME => 1,
+    );
+
+Readonly my $MAX_TREMBL_EVIDENCE_LEVEL_FOR_STANDARD => 2;
+Readonly my %source_selection_criteria_for_status
+  => (
+      'Reviewed'   => [ 'Uniprot/SWISSPROT',
+                        sub {
+                          return 'sequence_mapped';
+                        }, ],
+      'Unreviewed' => [ 'Uniprot/SPTREMBL', sub {
+                          my ( $level ) = @_;
+                          return ( $level <= $MAX_TREMBL_EVIDENCE_LEVEL_FOR_STANDARD ) ?
+                            'sequence_mapped' :
+                            "protein_evidence_gt_$MAX_TREMBL_EVIDENCE_LEVEL_FOR_STANDARD";
+                        }, ],
+    );
+
+Readonly my %protein_id_extraction_recipe_for_database
+  => (
+      'ChEMBL' => \&_get_protein_id_xref_from_embldb_xref,
+      'EMBL'   => \&_get_protein_id_xref_from_embldb_xref,
+    );
+sub _get_protein_id_xref_from_embldb_xref {
+  my ( $protein_id, $linkage_source_id, $source_id ) = @_;
+
+  # Strip the version number, if any, from the protein ID. At the same
+  # time, filter out entries with no ID - in which case the ID is a
+  # lone hyphen.
+  # FIXME:
+  #  - are versioned primary IDs still a thing? There are no such
+  #    entries in the Swiss-Prot file
+  #  - ditto primary ID being absent
+  my ( $unversioned_protein_id )
+    = ( $protein_id =~ m{
+                          \A
+                          # Allow hyphens if they are not
+                          # the first character
+                          ( [^-.] [^.]+ )
+                      }msx );
+
+  if ( ! defined $unversioned_protein_id ) {
+    return;
+  }
+
+  my $xref_link = {
+                   'ACCESSION'          => $unversioned_protein_id,
+                   'LABEL'              => $protein_id,
+                   'LINKAGE_ANNOTATION' => $source_id,
+                   'LINKAGE_SOURCE_ID'  => $linkage_source_id,
+                   'SOURCE_ID'          => $source_id,
+              };
+  return $xref_link;
+}
+
+
+
+sub new {
+  my ( $proto, $arg_ref ) = @_;
+
+  my $self = {
+              'maps'       => {},
+              'species_id' => $arg_ref->{'species_id'},
+              'xref_dba'   => $arg_ref->{'xref_dba'},
+            };
+  my $class = ref $proto || $proto;
+  bless $self, $class;
+
+  $self->_load_maps();
+
+  return $self;
+}
+
+
+sub DESTROY {
+  my ( $self ) = @_;
+
+  $self->finish();
+
+  return;
+}
+
+
+sub finish {
+  my ( $self ) = @_;
+
+  return;
+}
+
+
+# Transforms extracted record into form that can be consumed by
+# BaseAdaptor::upload_xref_object_graphs().
+sub transform {
+  my ( $self, $extracted_record ) = @_;
+
+  $self->{'extracted_record'} = $extracted_record;
+
+  my ( $accession, @synonyms )
+    = @{ $extracted_record->{'accession_numbers'} };
+  my $source_id = $self->_get_source_id();
+
+  my $xref_graph_node
+    = {
+       'ACCESSION'     => $accession,
+       'DESCRIPTION'   => $extracted_record->{'description'},
+       'INFO_TYPE'     => 'SEQUENCE_MATCH',
+       'LABEL'         => $accession,
+       'SEQUENCE'      => $extracted_record->{'sequence'},
+       'SEQUENCE_TYPE' => 'peptide',
+       'SOURCE_ID'     => $source_id,
+       'SPECIES_ID'    => $self->{'species_id'},
+       'STATUS'        => 'experimental',
+       'SYNONYMS'      => \@synonyms,
+     };
+
+  # UniProt Gene Names links come from the 'gene_names' fields
+  my $genename_dependent_xrefs
+    = $self->_make_links_from_gene_names( $accession, $source_id );
+  # Do not assign an empty array to DEPENDENT_XREFS, current insertion code
+  # doesn't like them.
+  if ( scalar @{ $genename_dependent_xrefs } > 0 ) {
+    push @{ $xref_graph_node->{'DEPENDENT_XREFS'} }, @{ $genename_dependent_xrefs };
+  }
+
+  # All other xref links come from crossreferences
+  my ( $direct_xrefs, $dependent_xrefs )
+    = $self->_make_links_from_crossreferences( $accession, $source_id );
+  # Do not assign empty arrays to FOO_XREFS, current insertion code
+  # doesn't like them.
+  if ( scalar @{ $direct_xrefs } > 0 ) {
+    push @{ $xref_graph_node->{'DIRECT_XREFS'} }, @{ $direct_xrefs };
+  }
+  if ( scalar @{ $dependent_xrefs } > 0 ) {
+    push @{ $xref_graph_node->{'DEPENDENT_XREFS'} }, @{ $dependent_xrefs };
+  }
+
+  return $xref_graph_node;
+}
+
+
+# Returns a hashref mapping source-name/priority pairs to source
+# IDs. Used by the steering code to e.g. handle the setting of release
+# numbers on sources.
+sub get_source_id_map {
+  my ( $self ) = @_;
+
+  # Just in case, even though we presently call _load_maps() in the
+  # constructor so it shouldn't be possible to call this method before
+  # maps have been loaded
+  if ( ! exists $self->{'maps'}->{'named_source_ids'} ) {
+    confess 'Source-ID map is missing';
+  }
+
+  return $self->{'maps'}->{'named_source_ids'};
+}
+
+
+sub _load_maps {
+  my ( $self ) = @_;
+
+  my $xref_dba = $self->{'xref_dba'};
+
+  my $source_id_map
+    = {
+       'Uniprot/SWISSPROT'
+       => {
+           'direct'          => undef,
+           'sequence_mapped' => undef,
+         },
+       'Uniprot/SPTREMBL'
+       => {
+           'direct'            => undef,
+           "protein_evidence_gt_$MAX_TREMBL_EVIDENCE_LEVEL_FOR_STANDARD" => undef,
+           'sequence_mapped'   => undef,
+         },
+     };
+  while ( my ( $source_name, $pri_ref ) = each %{ $source_id_map } ) {
+    foreach my $priority ( keys %{ $pri_ref } ) {
+      $pri_ref->{$priority}
+        = $xref_dba->get_source_id_for_source_name( $source_name,
+                                                    $priority );
+    }
+  }
+  $self->{'maps'}->{'named_source_ids'}
+    = $source_id_map;
+
+  my %dependent_source_map
+    = $xref_dba->get_xref_sources();
+  $self->{'maps'}->{'dependent_sources'}
+    = \%dependent_source_map;
+
+  return;
+}
+
+
+# Returns true if the current record describes an entry derived from
+# Ensembl, false otherwise.
+sub _entry_is_from_ensembl {
+  my ( $self ) = @_;
+
+  # The old parser's way of identifying proteins derived from Ensembl
+  # was to search for a comment topic "CAUTION" stating "The sequence
+  # shown here is derived from an Ensembl". It was confirmed with
+  # UniProt in November 2018 that this hadn't been done since late
+  # 2017, therefore we no longer check this.
+
+  # As of November 2018, the official way of identifying proteins
+  # derived from Ensembl is to look for a special citation identifying
+  # the record as such. There are several ways in which such special
+  # citations could be identified, it seems the simplest to look at
+  # "reference group name" fields to see if any of them says
+  # 'Ensembl'.
+  my $citation_groups
+    = $self->{'extracted_record'}->{'citation_groups'};
+  my $from_group_names
+    = List::Util::any { $_ eq 'Ensembl' } @{ $citation_groups };
+
+  return $from_group_names;
+}
+
+
+# Translate quality of the extracted entry into the matching Ensembl
+# source_id, optionally with an override of priority.
+sub _get_source_id {
+  my ( $self, $priority_override ) = @_;
+
+  my $source_id_map = $self->{'maps'}->{'named_source_ids'};
+
+  my $entry_quality = $self->{'extracted_record'}->{'quality'};
+  my $criteria = $source_selection_criteria_for_status{ $entry_quality->{'status'} };
+  my $priority_mapper = $criteria->[1];
+
+  my $source_name = $criteria->[0];
+  my $priority = $priority_override
+    // $priority_mapper->( $entry_quality->{'evidence_level'} );
+
+  return $source_id_map->{$source_name}->{$priority};
+}
+
+
+# Make xrefs from 'crossreferences' entries in the extracted record,
+# in a form suitable to attaching to the main xref's graph node as
+# consumed by upload_xref_object_graphs(). Ensembl crossreferences
+# become direct xrefs, everything else - dependent ones. If requested
+# we additionally generate protein_id dependent xrefs from appropriate
+# sources, i.e. EMBL and ChEMBL at present.
+sub _make_links_from_crossreferences {
+  my ( $self, $xref_accession, $xref_source_id ) = @_;
+
+  my $crossreferences = $self->{'extracted_record'}->{'crossreferences'};
+  my $dependent_sources = $self->{'maps'}->{'dependent_sources'};
+
+  my @direct_xrefs;
+  my @dependent_xrefs;
+
+ REF_SOURCE:
+  while ( my ( $source, $entries ) = each %{ $crossreferences } ) {
+
+    if ( ! $whitelisted_crossreference_sources{ $source } ) {
+      next REF_SOURCE;
+    }
+
+    if ( $source eq 'Ensembl' ) {
+
+    DIRECT_XREF:
+      foreach my $direct_ref ( @{ $entries } ) {
+        my $xref_link
+          = {
+             'STABLE_ID'    => $direct_ref->{'id'},
+             'ENSEMBL_TYPE' => 'Translation',
+             'LINKAGE_TYPE' => 'DIRECT',
+             'SOURCE_ID'    => $self->_get_source_id( 'direct' ),
+           };
+        push @direct_xrefs, $xref_link;
+      }
+
+    }
+    elsif ( exists $dependent_sources->{$source} ) {
+      my $dependent_source_id = $dependent_sources->{$source};
+
+    DEPENDENT_XREF:
+      foreach my $dependent_ref ( @{ $entries } ) {
+        my $xref_link
+          = {
+             'ACCESSION'          => $xref_accession,
+             'LINKAGE_ANNOTATION' => $dependent_source_id,
+             'LINKAGE_SOURCE_ID'  => $xref_source_id,
+             'SOURCE_ID'          => $dependent_source_id,
+           };
+        push @dependent_xrefs, $xref_link;
+
+        my $protein_id_xref_maker
+          = $protein_id_extraction_recipe_for_database{ $source };
+        if ( $whitelisted_crossreference_sources{ $PROTEIN_ID_SOURCE_NAME }
+             && ( defined $protein_id_xref_maker ) ) {
+
+          # Entries for the source 'protein_id' are constructed from
+          # crossreferences to other databases
+          my $protein_id_xref
+            = $protein_id_xref_maker->( $dependent_ref->{'id'},
+                                        $xref_source_id,
+                                        $dependent_sources->{$PROTEIN_ID_SOURCE_NAME}
+                                     );
+          if ( defined $protein_id_xref ) {
+            push @dependent_xrefs, $protein_id_xref;
+          }
+
+        }
+
+      }
+
+    }
+  }
+
+  return ( \@direct_xrefs, \@dependent_xrefs );
+}
+
+
+# Make Uniprot_gn dependent xrefs from 'gene_names' entries in the
+# extracted record, in a form suitable to attaching to the main xref's
+# graph node as consumed by upload_xref_object_graphs().
+sub _make_links_from_gene_names {
+  my ( $self, $xref_accession, $xref_source_id ) = @_;
+
+  my @genename_xrefs;
+
+  # Are we supposed to process this xref source to begin with?
+  if ( ! $whitelisted_crossreference_sources{ $UNIPROT_GN_SOURCE_NAME } ) {
+    return [];
+  }
+
+  # UniProt Gene Name xrefs are dependent so in order to avoid
+  # circular dependencies, do not generate them for proteins derived
+  # from Ensembl.
+  if ( $self->_entry_is_from_ensembl() ) {
+    return [];
+  }
+
+  my $gene_names = $self->{'extracted_record'}->{'gene_names'};
+  my $dependent_sources = $self->{'maps'}->{'dependent_sources'};
+  my $dependent_source_id = $dependent_sources->{$UNIPROT_GN_SOURCE_NAME};
+
+ GN_ENTRY:
+  foreach my $gn_entry ( @{ $gene_names } ) {
+    if ( ! exists $gn_entry->{'Name'} ) {
+      next GN_ENTRY;
+    }
+
+    my $name = $gn_entry->{'Name'};
+    my $xref = {
+                'ACCESSION'          => $xref_accession,
+                'LABEL'              => $name,
+                'LINKAGE_ANNOTATION' => $dependent_source_id,
+                'LINKAGE_SOURCE_ID'  => $xref_source_id,
+                'SOURCE_ID'          => $dependent_source_id,
+              };
+
+    my $synonyms = $gn_entry->{'Synonyms'};
+    if ( defined $synonyms ) {
+      push @{ $xref->{'SYNONYMS'} }, @{ $synonyms };
+    }
+
+    push @genename_xrefs, $xref;
+
+    # Regardless of how many gene-name entries a protein might have in
+    # UniProt, we only want at most *one* such xref - there are bits
+    # of Ensembl code which implicitly assume there can only be one
+    # xref per unique (accerssion,source_id,species_id) triplet and
+    # Uniprot_gn is essentially a last-resort source for when nothing
+    # else works. At least we should be able to consistently output
+    # the first encountered gene name (and synonyms), the old parser
+    # happily ignored the fact there can be multiple gene names and
+    # clobbered old names and synonyms every time a new one was
+    # encountered - potentially resulting in xrefs with the last
+    # encountered name but synonyms from an earlier one.
+    last GN_ENTRY;
+  }
+
+  return \@genename_xrefs;
+}
+
+
+1;


### PR DESCRIPTION
## Description

This PR ports DBASSParser, MIMParser, Mim2GeneParser and UniProtParser from _ensembl_ (branch _feature/xref_sprint_ for the former three, _feature/UniProtParserETL_ for the latter) to _ensembl-xref_.

## Use case

Part of the xref sprint. See ENSCORESW-2920, ENSCORESW-2926, ENSCORESW-2931 and ENSCORESW-2939.

## Benefits

DBASS, OMIM and UniProt xrefs will be parseable using the new infrastructure.

## Possible Drawbacks

None I can think of.

## Testing

I have confirmed that all four parsers run (using Alessandro's modified version of the xref pipeline, as per instructions) and produce identical output, timestamps nothwithstanding, as their _ensembl_ counterparts. Test suites will follow.
