### PR TITLE
Feature/refactor parsers

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/Parser/ArrayExpressParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/ArrayExpressParser.pm
@@ -72,8 +72,8 @@ The run method does the actual parsing and creation of xrefs and synonyms.
 Parser gets initialized as noted above and run is called from
 Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
 
-my $parser = Bio::EnsEMBL::Xref::Parser::MGI_Desc_Parser->new(..)
-$parser->run();
+my $parser = Bio::EnsEMBL::Xref::Parser::ArrayExpressParser-E<gt>new(..)
+$parser-E<gt>run();
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Xref/Parser/ArrayExpressParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/ArrayExpressParser.pm
@@ -67,6 +67,16 @@ my $default_ftp_server = 'ftp.ebi.ac.uk';
 my $default_ftp_dir =
   'pub/databases/microarray/data/atlas/bioentity_properties/ensembl';
 
+=head2
+The run method does the actual parsing and creation of xrefs and synonyms.
+Parser gets initialized as noted above and run is called from
+Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
+
+my $parser = Bio::EnsEMBL::Xref::Parser::MGI_Desc_Parser->new(..)
+$parser->run();
+
+=cut
+
 sub run {
 
   my ( $self, $ref_arg ) = @_;
@@ -82,7 +92,7 @@ sub run {
 
   # project could be ensembl or ensemblgenomes
   my $project;
-  if ( $file =~ /project[=][>](\S+?)[,]/ ) {
+  if ( $file =~ m/project[=][>](\S+?)[,]/xm ) {
     $project = $1;
   }
 
@@ -134,7 +144,10 @@ sub run {
     }
   }
 
-  print "Added $xref_count DIRECT xrefs\n" if ($verbose);
+  if ( $verbose ) {
+    print "Added $xref_count DIRECT xrefs\n";
+  }
+
   if ( !$xref_count ) {
    croak "No arrayexpress xref added\n";
   }
@@ -147,7 +160,7 @@ sub _get_gene_adaptor {
   my ( $self, $project, $species_name, $dba ) = @_;
 
   my $registry = "Bio::EnsEMBL::Registry";
-  
+
   my ($gene_adaptor);
 
   if ( defined $project && $project eq 'ensembl' ) {
@@ -179,7 +192,7 @@ sub _get_gene_adaptor {
     $gene_adaptor = $dba->get_GeneAdaptor();
   }
   else {
-    die( "Missing or unsupported project value. Supported values: ensembl, ensemblgenomes" );
+    confess "Missing or unsupported project value. Supported values: ensembl, ensemblgenomes";
   }
 
   return $gene_adaptor;
@@ -202,7 +215,7 @@ sub _get_species {
 
   my %species_lookup;
   foreach my $file (@files) {
-    my ($species) = split( /\./, $file );
+    my ($species) = split( m/\./xm, $file );
     $species_lookup{$species} = 1;
   }
   return \%species_lookup;

--- a/modules/Bio/EnsEMBL/Xref/Parser/DBASSParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/DBASSParser.pm
@@ -44,6 +44,15 @@ use parent qw( Bio::EnsEMBL::Xref::Parser );
 
 Readonly my $EXPECTED_NUMBER_OF_COLUMNS => 3;
 
+=head2 run
+The run method does the actual parsing and creation of xrefs and synonyms.
+Parser gets initialized as noted above and run is called from
+Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
+
+my $parser = Bio::EnsEMBL::Xref::Parser::BDASSParser-E<gt>new(..)
+$parser-E<gt>run();
+
+=cut
 
 sub run {
   my ( $self ) = @_;
@@ -185,7 +194,7 @@ sub is_file_header_valid {
 
   # All fields must be in order
   return List::Util::all { $_ } @fields_ok;
-}
+} ## end sub is_file_header_valid
 
 
 1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/MGIParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/MGIParser.pm
@@ -33,7 +33,7 @@ Bio::EnsEMBL::Xref::Parser::MGIParser
 
 =head1 DESCRIPTION
 
-A parser class to parse the MGI (official) source, 
+A parser class to parse the MGI (official) source,
 creating a DIRECT xref between MGI accession and ensembl mouse gene stable id ENSMUSG*
 
 -species = mus_musculus
@@ -43,7 +43,7 @@ creating a DIRECT xref between MGI accession and ensembl mouse gene stable id EN
 -columns = [accession symbol name position chrom ens_gene_stableid] ##ignore other columns
 
 example row:
- MGI:1915941	1110028C15Rik	RIKEN cDNA 1110028C15 gene	33.61	1	ENSMUSG00000026004
+ MGI:1915941E<9>1110028C15RikE<9>RIKEN cDNA 1110028C15 geneE<9>33.61E<9>1E<9>ENSMUSG00000026004
 
 
 =head1 SYNOPSIS
@@ -67,6 +67,16 @@ use DBI;
 use Text::CSV;
 
 use parent qw( Bio::EnsEMBL::Xref::Parser );
+
+=head2
+The run method does the actual parsing and creation of xrefs and synonyms.
+Parser gets initialized as noted above and run is called from
+Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
+
+my $parser = Bio::EnsEMBL::Xref::Parser::MGI_Desc_Parser->new(..)
+$parser->run();
+
+=cut
 
 sub run {
 

--- a/modules/Bio/EnsEMBL/Xref/Parser/MGI_Desc_Parser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/MGI_Desc_Parser.pm
@@ -42,7 +42,7 @@ also creates the synonyms extracted from the pipe seperated synonym_field
 -columns = [accession chromosome position start end strand label status marker marker_type feature_type synonym_field]
 
 example row:
-MGI:1926146	1	  23.44	43730602	43742564	+	1500015O10Rik	O	RIKEN cDNA 1500015O10 gene	Gene	protein coding gene	Ecrg4|augurin
+MGI:1926146E<9>1E<9>  23.44E<9>43730602E<9>43742564E<9>+E<9>1500015O10RikE<9>OE<9>RIKEN cDNA 1500015O10 geneE<9>GeneE<9>protein coding geneE<9>Ecrg4|augurin
 
 
 =head1 SYNOPSIS
@@ -73,6 +73,7 @@ Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
 
 my $parser = Bio::EnsEMBL::Xref::Parser::MGI_Desc_Parser->new(..)
 $parser->run();
+
 =cut
 
 sub run {
@@ -133,7 +134,7 @@ sub run {
     $xref_count++;
     my @synonyms;
     if ( defined( $acc_to_xref{$accession} ) ) {
-      @synonyms = split( /\|/, $data->{'synonym_field'} )
+      @synonyms = split( m/\|/xm, $data->{'synonym_field'} )
         if ( $data->{'synonym_field'} );
       foreach my $syn (@synonyms) {
         $xref_dba->add_synonym( $acc_to_xref{$accession}, $syn );

--- a/modules/Bio/EnsEMBL/Xref/Parser/MIMParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/MIMParser.pm
@@ -16,6 +16,51 @@ limitations under the License.
 
 =cut
 
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+=head1 DESCRIPTION
+
+This parser will read xrefs from a record file downloaded from the
+OMIM Web site. They should be assigned to two different xref
+sources: MIM_GENE and MIM_MORBID. MIM xrefs are linked to EntrezGene
+entries so the parser does not match them to Ensembl; this will be
+taken care of when EntrezGene entries are matched.
+
+OMIM records are multiline. Each record begins with a specific tag
+line and consists of a number of fields. Each field starts with its
+own start-tag line (i.e. the data proper only appears after a
+newline) and continues until the beginning of either the next field
+in the same record, the next record, or the end-of-input tag. The
+overall structure looks as follows:
+
+  *RECORD*
+  *FIELD* NO
+  *FIELD* TI
+  *FIELD* TX
+  ...
+  *RECORD*
+  *FIELD* NO
+  *FIELD* TI
+  ...
+  *RECORD*
+  *FIELD* NO
+  ...
+  *FIELD* CD
+  *FIELD* ED
+  *THEEND*
+
+All the data relevant to the parser can be found in the TI field.
+
+=cut
+
 package Bio::EnsEMBL::Xref::Parser::MIMParser;
 
 use strict;
@@ -26,37 +71,15 @@ use Readonly;
 
 use parent qw( Bio::EnsEMBL::Xref::Parser );
 
-# This parser will read xrefs from a record file downloaded from the
-# OMIM Web site. They should be assigned to two different xref
-# sources: MIM_GENE and MIM_MORBID. MIM xrefs are linked to EntrezGene
-# entries so the parser does not match them to Ensembl; this will be
-# taken care of when EntrezGene entries are matched.
-#
-# OMIM records are multiline. Each record begins with a specific tag
-# line and consists of a number of fields. Each field starts with its
-# own start-tag line (i.e. the data proper only appears after a
-# newline) and continues until the beginning of either the next field
-# in the same record, the next record, or the end-of-input tag. The
-# overall structure looks as follows:
-#
-#   *RECORD*
-#   *FIELD* NO
-#   *FIELD* TI
-#   *FIELD* TX
-#   ...
-#   *RECORD*
-#   *FIELD* NO
-#   *FIELD* TI
-#   ...
-#   *RECORD*
-#   *FIELD* NO
-#   ...
-#   *FIELD* CD
-#   *FIELD* ED
-#   *THEEND*
-#
-# All the data relevant to the parser can be found in the TI field.
+=head2 run
+The run method does the actual parsing and creation of direct xrefs.
+Parser gets initialized as noted above and run is called from
+Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
 
+my $parser = Bio::EnsEMBL::Xref::Parser::HPAParser-E<gt>new(..)
+$parser-E<gt>run();
+
+=cut
 
 sub run {
 
@@ -224,6 +247,11 @@ sub run {
 } ## end sub run
 
 
+=head2 extract_ti
+Extract the TI tag fields from the records
+
+=cut
+
 sub extract_ti {
   my ( $input_record ) = @_;
 
@@ -239,8 +267,13 @@ sub extract_ti {
                         }msx );
 
   return $ti;
-}
+} ## end sub extract_ti
 
+
+=head2 parse_ti
+Extract the type, accession and description for the TI field.
+
+=cut
 
 sub parse_ti {
   my ( $ti ) = @_;
@@ -263,8 +296,6 @@ sub parse_ti {
                          }msx );
 
   return @captures;
-}
-
-
+} ## end sub parse_ti
 
 1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/Mim2GeneParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/Mim2GeneParser.pm
@@ -16,6 +16,16 @@ limitations under the License.
 
 =cut
 
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
 package Bio::EnsEMBL::Xref::Parser::Mim2GeneParser;
 
 # For non-destructive substitutions in regexps (/r flag)
@@ -34,6 +44,15 @@ use parent qw( Bio::EnsEMBL::Xref::Parser );
 
 Readonly my $EXPECTED_NUMBER_OF_COLUMNS => 5;
 
+=head2 run
+The run method does the actual parsing and creation of direct xrefs.
+Parser gets initialized as noted above and run is called from
+Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
+
+my $parser = Bio::EnsEMBL::Xref::Parser::Mim2GeneParser-E<gt>new(..)
+$parser-E<gt>run();
+
+=cut
 
 sub run {
   my ( $self ) = @_;
@@ -74,11 +93,11 @@ sub run {
   # Initialise all counters to 0 so that we needn't handle possible undefs
   # while printing the summary
   my %counters = (
-                  'all_entries'                          => 0,
-                  'dependent_on_entrez'                  => 0,
-                  'direct_ensembl'                       => 0,
-                  'missed_master'                        => 0,
-                  'missed_omim'                          => 0,
+                  'all_entries'         => 0,
+                  'dependent_on_entrez' => 0,
+                  'direct_ensembl'      => 0,
+                  'missed_master'       => 0,
+                  'missed_omim'         => 0,
                 );
 
  RECORD:
@@ -182,7 +201,7 @@ sub run {
 } ## end sub run
 
 
-=head2 is_file_header_valid
+=head2 is_header_file_valid
 
   Arg [1]    : String file header line
   Example    : if (!is_file_header_valid($header_line)) {
@@ -204,14 +223,13 @@ sub is_header_file_valid {
 
   my @fields_ok;
 
-  Readonly my @field_patterns
-    => (
-        qr{ \A [#]? \s* MIM[ ]Number }msx,
-        qr{ MIM[ ]Entry[ ]Type }msx,
-        qr{ Entrez[ ]Gene[ ]ID }msx,
-        qr{ Approved[ ]Gene[ ]Symbol }msx,
-        qr{ Ensembl[ ]Gene[ ]ID }msx,
-      );
+  Readonly my @field_patterns => (
+    qr{ \A [#]? \s* MIM[ ]Number }msx,
+    qr{ MIM[ ]Entry[ ]Type }msx,
+    qr{ Entrez[ ]Gene[ ]ID }msx,
+    qr{ Approved[ ]Gene[ ]Symbol }msx,
+    qr{ Ensembl[ ]Gene[ ]ID }msx,
+  );
 
   my $header_field;
   foreach my $pattern (@field_patterns) {
@@ -222,7 +240,7 @@ sub is_header_file_valid {
 
   # All fields must have matched
   return List::Util::all { $_ } @fields_ok;
-}
+} ## end sub is_header_file_valid
 
 
 =head2 process_xref_entry
@@ -258,12 +276,13 @@ sub process_xref_entry {
   else {
     foreach my $ent_id ( @{ $arg_ref->{'entrez_xrefs'} } ) {
       $arg_ref->{'counters'}->{'dependent_on_entrez'}++;
-      $xref_dba->add_dependent_xref_maponly( $arg_ref->{'mim_xref_id'},
-                                         $arg_ref->{'mim_source_id'},
-                                         $ent_id,
-                                         $arg_ref->{'entrez_source_id'},
-                                         1
-                                      );
+      $xref_dba->add_dependent_xref_maponly(
+        $arg_ref->{'mim_xref_id'},
+        $arg_ref->{'mim_source_id'},
+        $ent_id,
+        $arg_ref->{'entrez_source_id'},
+        1
+      );
     }
   }
 

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
@@ -34,10 +34,20 @@ Readonly my $DEFAULT_LOADER_BATCH_SIZE         => 1000;
 Readonly my $DEFAULT_LOADER_CHECKPOINT_SECONDS => 300;
 
 Readonly my %source_name_for_section => (
-                                         'Swiss-Prot' => 'Uniprot/SWISSPROT',
-                                         'TrEMBL'     => 'Uniprot/SPTREMBL',
-                                       );
+  'Swiss-Prot' => 'Uniprot/SWISSPROT',
+  'TrEMBL'     => 'Uniprot/SPTREMBL',
+);
 
+
+=head2 run
+The run method does the actual parsing and creation of direct xrefs.
+Parser gets initialized as noted above and run is called from
+Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
+
+my $parser = Bio::EnsEMBL::Xref::Parser::UniProtParser-E<gt>new(..)
+$parser-E<gt>run();
+
+=cut
 
 sub run {
   my ( $self ) = @_;
@@ -131,10 +141,16 @@ sub run {
   }
 
   return 0;
-}
+} ## end sub run
 
 
-# Extract Swiss-Prot and TrEMBL release info from the release file
+=head2 _get_release_numbers_from_file
+  Arg [1]    : release_file_name
+  Arg [2]    : verbose
+  Description: Extract Swiss-Prot and TrEMBL release info from the release file
+
+=cut
+
 sub _get_release_numbers_from_file {
   my ( $self, $release_file_name, $verbose ) = @_;
 
@@ -169,7 +185,15 @@ sub _get_release_numbers_from_file {
   $release_io->close();
 
   return $release_numbers;
-}
+} ## end sub _get_release_numbers_from_file
+
+
+=head2
+  Arg [1]    : Source ID Map
+  Arg [2]    : Release number
+  Description: Set the release number for the UniProt Source
+
+=cut
 
 sub _set_release_numbers_on_uniprot_sources {
   my ( $self, $source_id_map, $release_numbers ) = @_;
@@ -184,6 +208,6 @@ sub _set_release_numbers_on_uniprot_sources {
   }
 
   return;
-}
+} ## end sub _set_release_numbers_on_uniprot_sources
 
 1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/XenopusJamboreeParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/XenopusJamboreeParser.pm
@@ -62,6 +62,16 @@ use Text::CSV;
 
 use parent qw( Bio::EnsEMBL::Xref::Parser );
 
+=head2
+The run method does the actual parsing and creation of xrefs and synonyms.
+Parser gets initialized as noted above and run is called from
+Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
+
+my $parser = Bio::EnsEMBL::Xref::Parser::MGI_Desc_Parser->new(..)
+$parser->run();
+
+=cut
+
 sub run {
   my ( $self, $ref_arg ) = @_;
   my $source_id  = $self->{source_id};
@@ -120,8 +130,8 @@ sub run {
 
 
 # Regex handles lines in the following desc formats
-# XB-GENE-940410	unnamed	Putative ortholog of g2/mitotic-specific cyclin B3, 3 of 14	ENSXETG00000007206
-# XB-GENE-956173	hba4	alpha-T4 globin, Putative ortholog of hemoglobin alpha chain. [Source:Uniprot/SWISSPROT;Acc:P01922], 2 of 3	ENSXETG00000001141
+# XB-GENE-940410E<9>unnamedE<9>Putative ortholog of g2/mitotic-specific cyclin B3, 3 of 14E<9>ENSXETG00000007206
+# XB-GENE-956173E<9>hba4E<9>alpha-T4 globin, Putative ortholog of hemoglobin alpha chain. [Source:Uniprot/SWISSPROT;Acc:P01922], 2 of 3E<9>ENSXETG00000001141
 
 sub parse_description {
   my ( $self, $desc ) = @_;

--- a/modules/Bio/EnsEMBL/Xref/Parser/XenopusJamboreeParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/XenopusJamboreeParser.pm
@@ -62,7 +62,7 @@ use Text::CSV;
 
 use parent qw( Bio::EnsEMBL::Xref::Parser );
 
-=head2
+=head2 run
 The run method does the actual parsing and creation of xrefs and synonyms.
 Parser gets initialized as noted above and run is called from
 Bio::EnsEMBL::Production::Pipeline::Xrefs::ParseSource
@@ -126,12 +126,15 @@ sub run {
     if ($verbose);
 
   return 0;
-}
+} ## end sub run
 
 
-# Regex handles lines in the following desc formats
-# XB-GENE-940410E<9>unnamedE<9>Putative ortholog of g2/mitotic-specific cyclin B3, 3 of 14E<9>ENSXETG00000007206
-# XB-GENE-956173E<9>hba4E<9>alpha-T4 globin, Putative ortholog of hemoglobin alpha chain. [Source:Uniprot/SWISSPROT;Acc:P01922], 2 of 3E<9>ENSXETG00000001141
+=head2 parse_description
+Regex handles lines in the following desc formats:
+XB-GENE-940410E<9>unnamedE<9>Putative ortholog of g2/mitotic-specific cyclin B3, 3 of 14E<9>ENSXETG00000007206
+XB-GENE-956173E<9>hba4E<9>alpha-T4 globin, Putative ortholog of hemoglobin alpha chain. [Source:Uniprot/SWISSPROT;Acc:P01922], 2 of 3E<9>ENSXETG00000001141
+
+=cut
 
 sub parse_description {
   my ( $self, $desc ) = @_;
@@ -142,6 +145,6 @@ sub parse_description {
   # Remove labels of type 5 of 14 from the description
   $desc =~ s/,\s+[0-9]+\s+of\s+[0-9]+//xms;
   return $desc;
-}
+} ## end sub parse_description
 
 1;

--- a/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/DependentXref.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/DependentXref.pm
@@ -22,6 +22,15 @@ use warnings;
 
 use parent 'DBIx::Class::ResultSet';
 
+
+=head2 fetch_dependent_xref
+  Arg []     : direct_accession
+  Arg []     : dependent_accession
+  Description: Fetch the dependent xref
+  Return     : DBIx::Class::ResultSet
+
+=cut
+
 sub fetch_dependent_xref {
   my ($self,$direct_accession,$dependent_accession) = @_;
 
@@ -31,8 +40,8 @@ sub fetch_dependent_xref {
     }, {
       join => [ 'master_xref','dependent_xref']
     });
-  
+
   return $hit;
-}
+} ## end sub fetch_dependent_xref
 
 1;

--- a/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/Synonym.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/Synonym.pm
@@ -23,7 +23,8 @@ use warnings;
 
 use parent 'DBIx::Class::ResultSet';
 
-=head2
+
+=head2 check_synonym
 Search for the given xref_id and synonym
   {
     xref_id => $params->{xref_id},
@@ -38,6 +39,6 @@ sub check_synonym {
 
   return 1 if defined $hit;
   return;
-}
+} ## end sub check_synonym
 
 1;

--- a/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/Xref.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/Xref.pm
@@ -22,6 +22,16 @@ use warnings;
 
 use parent 'DBIx::Class::ResultSet';
 
+
+=head2 check_direct_xref
+  Arg [1]    : HashRef of parameters
+                 $params->{accession},
+                 $params->{display_label},
+                 $params->{description}
+  Description:
+
+=cut
+
 sub check_direct_xref {
   my ($self,$params) = @_;
 
@@ -33,6 +43,6 @@ sub check_direct_xref {
   # }
   return 1 if defined $hit;
   return;
-}
+} ## end sub check_direct_xref
 
 1;

--- a/modules/Bio/EnsEMBL/Xref/Test/TestDB.pm
+++ b/modules/Bio/EnsEMBL/Xref/Test/TestDB.pm
@@ -47,6 +47,12 @@ has reuse => (
   default => 0,
 );
 
+
+=head2 _guess_config
+  Default configuration file
+
+=cut
+
 sub _guess_config {
   return 'testdb.conf';
 }
@@ -66,6 +72,11 @@ around '_init_config' => sub {
   return;
 };
 
+
+=head2 DEMOLISH
+  Base function for the removal of test databases
+
+=cut
 
 sub DEMOLISH {
   my $self = shift;


### PR DESCRIPTION
## Description

Fixes for the formatting of a lot of the documentation and formatting of the regexs so that they pass perlcritic.

## Possible Drawbacks

Did not make changes to the FetchFiles.pm and UniProt*.pm modules on the most part as these are already being handled by @mkszuba and @nerdstrike.

## Testing

The FetchFiles and UniProt parsers still fail, but changes are in other branches.

