### PR TITLE
Feature/reactome parser

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
@@ -652,27 +652,6 @@ sub add_meta_pair {
   return;
 } ## end sub add_meta_pair
 
-=head2 _add_species_alias
-  Arg [1]    : species_id
-  Arg [2]    : alias
-  Description: Insert new entries in species table
-  Return type:
-  Caller     : Test
-
-=cut
-
-sub _add_species_alias {
-
-  my ( $self, $species_id, $alias) = @_;
-
-  my $sth = $self->dbi->prepare_cached(
-    'INSERT INTO species (species_id, taxonomy_id, name, aliases) VALUES (?, ?, ?, ?)' );
-  $sth->execute( $species_id, $species_id, $alias, $alias);
-  $sth->finish();
-
-  return;
-} ## end sub _add_species_alias
-
 
 =head2 get_xref_sources
   Description: Create a hash of all the source names for xrefs

--- a/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
@@ -652,27 +652,6 @@ sub add_meta_pair {
   return;
 } ## end sub add_meta_pair
 
-=head2 _add_source_id
-  Arg [1]    : source_id
-  Arg [2]    : name
-  Description: Insert new entries in source table
-  Return type:
-  Caller     : Test
-
-=cut
-
-sub _add_source_id {
-
-  my ( $self, $source_id, $name) = @_;
-
-  my $sth = $self->dbi->prepare_cached(
-    'INSERT INTO source (source_id, name, ordered) VALUES (?, ?, 1)' );
-  $sth->execute( $source_id, $name);
-  $sth->finish();
-
-  return;
-} ## end sub _add_source_id
-
 =head2 _add_species_alias
   Arg [1]    : species_id
   Arg [2]    : alias

--- a/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
@@ -207,6 +207,7 @@ sub get_source_id_for_source_name {
     }
     confess $msg;
   }
+  $sth->finish();
 
   return $source_id;
 } ## end sub get_source_id_for_source_name
@@ -650,6 +651,48 @@ sub add_meta_pair {
 
   return;
 } ## end sub add_meta_pair
+
+=head2 _add_source_id
+  Arg [1]    : source_id
+  Arg [2]    : name
+  Description: Insert new entries in source table
+  Return type:
+  Caller     : Test
+
+=cut
+
+sub _add_source_id {
+
+  my ( $self, $source_id, $name) = @_;
+
+  my $sth = $self->dbi->prepare_cached(
+    'INSERT INTO source (source_id, name, ordered) VALUES (?, ?, 1)' );
+  $sth->execute( $source_id, $name);
+  $sth->finish();
+
+  return;
+} ## end sub _add_source_id
+
+=head2 _add_species_alias
+  Arg [1]    : species_id
+  Arg [2]    : alias
+  Description: Insert new entries in species table
+  Return type:
+  Caller     : Test
+
+=cut
+
+sub _add_species_alias {
+
+  my ( $self, $species_id, $alias) = @_;
+
+  my $sth = $self->dbi->prepare_cached(
+    'INSERT INTO species (species_id, taxonomy_id, name, aliases) VALUES (?, ?, ?, ?)' );
+  $sth->execute( $species_id, $species_id, $alias, $alias);
+  $sth->finish();
+
+  return;
+} ## end sub _add_species_alias
 
 
 =head2 get_xref_sources

--- a/modules/Bio/EnsEMBL/Xref/Parser/ReactomeDirectParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/ReactomeDirectParser.pm
@@ -1,0 +1,155 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Xref::Parser::ReactomeDirectParser
+
+=head1 DESCRIPTION
+
+A parser class to parse the Reactome file for direct mappings to Ensembl..
+
+-data_uri = http://www.reactome.org/download/current/Ensembl2Reactome_All_Levels.txt
+-file_format = TSV
+-columns = [ensembl_stable_id reactome_acc reactome_url description status species]
+
+
+=head1 SYNOPSIS
+
+  my $parser = Bio::EnsEMBL::Xref::Parser::ReactomeDirectParser->new(
+    source_id  => 85,
+    species_id => 9696,
+    files      => ['Ensembl2Reactome_All_Levels.txt'],
+    xref_dba   => $xref_dba
+  );
+
+  $parser->run();
+=cut
+
+
+package Bio::EnsEMBL::Xref::Parser::ReactomeDirectParser;
+
+use strict;
+use warnings;
+use Carp;
+use Text::CSV;
+
+use parent qw( Bio::EnsEMBL::Xref::Parser );
+
+=head2 run
+  Description: Runs the ReactomeDirectParser
+  Return type: N/A
+  Caller     : internal
+=cut
+
+sub run {
+  my ( $self ) = @_;
+
+  my $source_id  = $self->{source_id};
+  my $species_id = $self->{species_id};
+  my $files      = $self->{files};
+  my $xref_dba   = $self->{xref_dba};
+  my $verbose    = $self->{verbose} // 0;
+
+  if ( (!defined $source_id) || (!defined $species_id) || (!defined $files) ) {
+    confess "Need to pass source_id, species_id and files as pairs";
+  }
+
+  my $file = shift @{$files};
+
+  my $gene_reactome_source_id =
+    $xref_dba->get_source_id_for_source_name( "reactome_gene" );
+  my $transcript_reactome_source_id =
+    $xref_dba->get_source_id_for_source_name( "reactome_transcript" );
+
+#e.g.
+#ENSG00000000419 R-HSA-162699    https://reactome.org/PathwayBrowser/#/R-HSA-162699      Synthesis of dolichyl-phosphate mannose TAS     Homo sapiens
+#ENSG00000000419 R-HSA-163125    https://reactome.org/PathwayBrowser/#/R-HSA-163125      Post-translational modification: synthesis of GPI-anchored proteins     TAS     Homo sapiens
+#ENSG00000000419 R-HSA-1643685   https://reactome.org/PathwayBrowser/#/R-HSA-1643685     Disease TAS     Homo sapiens
+
+
+  my $file_io = $xref_dba->get_filehandle($file);
+
+  if ( !defined $file_io ) {
+    confess "Can't open Ensembl_Reactome file '$file'\n";
+  }
+
+  my $input_file = Text::CSV->new({
+    sep_char       => "\t",
+    empty_is_undef => 1
+  }) or confess "Cannot use file '$file': " . Text::CSV->error_diag();
+
+
+  # 2 extra columns are ignored
+  $input_file->column_names( [ 'ensembl_stable_id', 'accession', 'url', 'description', 'status', 'species'] );
+
+  # Create a hash of all valid names for this species
+  my %species2alias = $xref_dba->species_id2name();
+  if (!defined $species2alias{$species_id}) { 
+    confess "No alias found for $species_id";
+  }
+  my @aliases = @{$species2alias{$species_id}};
+  my %alias2species_id = map {$_, 1} @aliases;
+
+  my ($reactome_source_id, $type, $species);
+  while ( my $data = $input_file->getline_hr( $file_io ) ) {
+    $species = $data->{'species'};
+    $species =~ s/\s/_/;
+    $species = lc($species);
+    if ( !$alias2species_id{$species} ) {
+      next;
+    }
+    if ( $data->{'ensembl_stable_id'} =~ /G[0-9]*$/) {
+      $type = 'gene';
+      $reactome_source_id = $gene_reactome_source_id;
+    } elsif ( $data->{'ensembl_stable_id'} =~ /T[0-9]*$/) {
+      $type = 'transcript';
+      $reactome_source_id = $transcript_reactome_source_id;
+    } else {
+    # Stable ID cannot be identified, skip the entry
+      next;
+    }
+    $xref_dba->add_to_direct_xrefs({
+        acc        => $data->{'accession'},
+        label      => $data->{'accession'},
+        desc       => $data->{'description'},
+        stable_id  => $data->{'ensembl_stable_id'},
+        type       => $type,
+        source_id  => $reactome_source_id,
+        species_id => $species_id,
+        info_type  => "DIRECT"
+    });
+  }
+
+  $input_file->eof or confess "Error parsing file $file: " . $input_file->error_diag();
+  $file_io->close();
+
+  return 0;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/ReactomeUniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/ReactomeUniProtParser.pm
@@ -129,14 +129,17 @@ sub run {
       next;
     }
     if ( defined $uniprot{$data->{'uniprot_accession'}} ) {
-      $xref_dba->add_dependent_xref({
-        acc        => $data->{'accession'},
-        label      => $data->{'accession'},
-        desc       => $data->{'description'},
-        source_id  => $reactome_source_id,
-        species_id => $species_id,
-        info_type  => "DEPENDENT"
-      });
+      foreach my $master_xref_id (@{$uniprot{$data->{'uniprot_accession'}}} ) {
+        $xref_dba->add_dependent_xref({
+          acc            => $data->{'accession'},
+          label          => $data->{'accession'},
+          desc           => $data->{'description'},
+          master_xref_id => $master_xref_id, 
+          source_id      => $reactome_source_id,
+          species_id     => $species_id,
+          info_type      => "DEPENDENT"
+        });
+      }
     }
   }
 

--- a/modules/Bio/EnsEMBL/Xref/Parser/ReactomeUniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/ReactomeUniProtParser.pm
@@ -1,0 +1,149 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Xref::Parser::ReactomeUniProtParser
+
+=head1 DESCRIPTION
+
+A parser class to parse the Reactome file for UniProt mappings.
+
+-data_uri = http://www.reactome.org/download/current/UniProt2Reactome_All_Levels.txt
+-file_format = TSV
+-columns = [uniprot_acc reactome_acc reactome_url description status species]
+
+
+=head1 SYNOPSIS
+
+  my $parser = Bio::EnsEMBL::Xref::Parser::ReactomeUniProtParser->new(
+    source_id  => 85,
+    species_id => 9696,
+    files      => ['UniProt2Reactome_All_Levels.txt'],
+    xref_dba   => $xref_dba
+  );
+
+  $parser->run();
+=cut
+
+
+package Bio::EnsEMBL::Xref::Parser::ReactomeUniProtParser;
+
+use strict;
+use warnings;
+use Carp;
+use Text::CSV;
+
+use parent qw( Bio::EnsEMBL::Xref::Parser );
+
+=head2 run
+  Description: Runs the ReactomeUniProtParser
+  Return type: N/A
+  Caller     : internal
+=cut
+
+sub run {
+  my ( $self ) = @_;
+
+  my $source_id  = $self->{source_id};
+  my $species_id = $self->{species_id};
+  my $files      = $self->{files};
+  my $xref_dba   = $self->{xref_dba};
+  my $verbose    = $self->{verbose} // 0;
+
+  if ( (!defined $source_id) || (!defined $species_id) || (!defined $files) ) {
+    confess "Need to pass source_id, species_id and files as pairs";
+  }
+
+  my $file = shift @{$files};
+
+  my $reactome_source_id =
+    $xref_dba->get_source_id_for_source_name( "reactome", "uniprot" );
+
+#e.g.
+#A0A075B6P5  R-HSA-109582  https://reactome.org/PathwayBrowser/#/R-HSA-109582  Hemostasis  TAS  Homo sapiens
+#A0A075B6P5  R-HSA-1280218  https://reactome.org/PathwayBrowser/#/R-HSA-1280218  Adaptive Immune System  TAS  Homo sapiens
+#A0A075B6P5  R-HSA-1280218  https://reactome.org/PathwayBrowser/#/R-HSA-1280218  Adaptive Immune System  IEA  Homo sapiens
+
+
+  my $file_io = $xref_dba->get_filehandle($file);
+
+  if ( !defined $file_io ) {
+    confess "Can't open UniProt_Reactome file '$file'\n";
+  }
+
+  my $input_file = Text::CSV->new({
+    sep_char       => "\t",
+    empty_is_undef => 1
+  }) or confess "Cannot use file '$file': " . Text::CSV->error_diag();
+
+
+  # 2 extra columns are ignored
+  $input_file->column_names( [ 'uniprot_accession', 'accession', 'url', 'description', 'status', 'species'] );
+  my (%uniprot) = 
+    %{ $xref_dba->get_valid_codes( "uniprot/", $species_id ) };
+
+  if (!%uniprot) {
+    confess "No UniProt xrefs found, cannot parse dependent Reactome mappings";
+  }
+
+  # Create a hash of all valid names for this species
+  my %species2alias = $xref_dba->species_id2name();
+  if (!defined $species2alias{$species_id}) {
+    confess "No alias found for $species_id";
+  }
+  my @aliases = @{$species2alias{$species_id}};
+  my %alias2species_id = map {$_, 1} @aliases;
+
+  my $species;
+  while ( my $data = $input_file->getline_hr( $file_io ) ) {
+    $species = $data->{'species'};
+    $species =~ s/\s/_/;
+    $species = lc($species);
+    if ( !$alias2species_id{$species} ) {
+      next;
+    }
+    if ( defined $uniprot{$data->{'uniprot_accession'}} ) {
+      $xref_dba->add_dependent_xref({
+        acc        => $data->{'accession'},
+        label      => $data->{'accession'},
+        desc       => $data->{'description'},
+        source_id  => $reactome_source_id,
+        species_id => $species_id,
+        info_type  => "DEPENDENT"
+      });
+    }
+  }
+
+  $input_file->eof or confess "Error parsing file $file: " . $input_file->error_diag();
+  $file_io->close();
+
+  return 0;
+}
+
+1;

--- a/modules/t/baseadaptor.t
+++ b/modules/t/baseadaptor.t
@@ -108,6 +108,21 @@ is(
   $xref_dba->get_source_id_for_source_name('RefSeq'),
   $source->source_id, 'get_source_id_for_source_name' );
 
+# Add a second example source to the db
+my $source2 = $db->schema->resultset('Source')->create({
+  name                 => 'Second_fake_source',
+  status               => 'KNOWN',
+  source_release       => '38',
+  download             => 'Y',
+  priority             => 1,
+  priority_description => 'Like a boss',
+  ordered              => 10
+});
+
+is(
+  $xref_dba->get_source_id_for_source_name('RefSeq'),
+  $source->source_id, 'get_source_id_for_source_name' );
+
 
 # get_source_ids_for_source_name_pattern
 throws_ok
@@ -117,6 +132,7 @@ throws_ok
 ok(
   defined $xref_dba->get_source_ids_for_source_name_pattern('fake_name'),
   'get_source_ids_for_source_name_pattern - Array returned' );
+
 is(
   $xref_dba->get_source_ids_for_source_name_pattern('RefSeq'),
   $source->source_id, 'get_source_ids_for_source_name_pattern' );

--- a/modules/t/reactome_direct.t
+++ b/modules/t/reactome_direct.t
@@ -30,6 +30,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Exception;
+use Test::Warnings;
 use FindBin '$Bin';
 use lib "$Bin/";
 
@@ -49,9 +50,24 @@ my $xref_dba = Bio::EnsEMBL::Xref::DBSQL::BaseAdaptor->new(
   port   => $config{port}
 );
 
-$xref_dba->_add_source_id(86, 'reactome_gene');
-$xref_dba->_add_source_id(87, 'reactome_transcript');
-$xref_dba->_add_species_alias(9606, 'homo_sapiens');
+my $species = $db->schema->resultset('Species')->create({
+  species_id  => 9606,
+  taxonomy_id => 9606,
+  name        => 'Homo sapiens',
+  aliases     => 'homo_sapiens'
+});
+
+my $reactome_gene_source = $db->schema->resultset('Source')->create({
+  source_id => 86,
+  name      => 'reactome_gene',
+  ordered   => 1
+});
+
+my $reactome_transcript_source = $db->schema->resultset('Source')->create({
+  source_id => 87,
+  name      => 'reactome_transcript',
+  ordered   => 1
+});
 
 use_ok 'Bio::EnsEMBL::Xref::Parser::ReactomeDirectParser';
 

--- a/modules/t/reactome_direct.t
+++ b/modules/t/reactome_direct.t
@@ -1,0 +1,87 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use FindBin '$Bin';
+use lib "$Bin/";
+
+use Bio::EnsEMBL::Xref::Test::TestDB;
+use Bio::EnsEMBL::Xref::DBSQL::BaseAdaptor;
+
+use_ok 'Bio::EnsEMBL::Xref::Parser';
+
+my $db = Bio::EnsEMBL::Xref::Test::TestDB->new();
+my %config = %{ $db->config };
+
+my $xref_dba = Bio::EnsEMBL::Xref::DBSQL::BaseAdaptor->new(
+  host   => $config{host},
+  dbname => $config{db},
+  user   => $config{user},
+  pass   => $config{pass},
+  port   => $config{port}
+);
+
+$xref_dba->_add_source_id(86, 'reactome_gene');
+$xref_dba->_add_source_id(87, 'reactome_transcript');
+$xref_dba->_add_species_alias(9606, 'homo_sapiens');
+
+use_ok 'Bio::EnsEMBL::Xref::Parser::ReactomeDirectParser';
+
+my $parser = Bio::EnsEMBL::Xref::Parser::ReactomeDirectParser->new(
+ source_id  => 85,
+ species_id => 9606,
+ files      => ["$Bin/test-data/ensembl_reactome.txt"],
+ xref_dba   => $xref_dba
+);
+
+isa_ok( $parser, 'Bio::EnsEMBL::Xref::Parser::ReactomeDirectParser' );
+
+$parser->run();
+
+ok(
+ $db->schema->resultset('Xref')->check_direct_xref(
+  {
+   accession   => "R-HSA-162699",
+   label       => 'R-HSA-162699',
+   description => 'Synthesis of dolichyl-phosphate mannose',
+   source_id   => 86,
+   species_id  => 9606
+  }
+ ),
+ 'Sample Reactome direct Xref has been inserted'
+);
+
+# Test if all the rows were inserted
+is($db->schema->resultset('Xref')->count, 6, "All 6 human rows were inserted");
+
+
+done_testing();
+

--- a/modules/t/reactome_uniprot.t
+++ b/modules/t/reactome_uniprot.t
@@ -1,0 +1,106 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use FindBin '$Bin';
+use lib "$Bin/";
+
+use Bio::EnsEMBL::Xref::Test::TestDB;
+use Bio::EnsEMBL::Xref::DBSQL::BaseAdaptor;
+
+use_ok 'Bio::EnsEMBL::Xref::Parser';
+
+my $db = Bio::EnsEMBL::Xref::Test::TestDB->new();
+my %config = %{ $db->config };
+
+my $xref_dba = Bio::EnsEMBL::Xref::DBSQL::BaseAdaptor->new(
+  host   => $config{host},
+  dbname => $config{db},
+  user   => $config{user},
+  pass   => $config{pass},
+  port   => $config{port}
+);
+
+my $species = $db->schema->resultset('Species')->create({
+  species_id  => 9606,
+  taxonomy_id => 9606,
+  name        => 'Homo sapiens',
+  aliases     => 'homo_sapiens'
+});
+
+my $reactome_uniprot_source = $db->schema->resultset('Source')->create({
+  source_id            => 86,
+  name                 => 'reactome',
+  priority_description => 'uniprot',
+  ordered              => 1
+});
+
+my $uniprot_source = $db->schema->resultset('Source')->create({
+  source_id            => 1,
+  name                 => 'UniProt/SWISSPROT',
+  ordered              => 1
+});
+
+my $uniprot_xref = $db->schema->resultset('Xref')->create({
+  xref_id    => 1,
+  accession  => 'A0A075B6P5',
+  source_id  => 1,
+  species_id => 9606,
+  info_type => 'DIRECT',
+  info_text => ''
+});
+
+
+use_ok 'Bio::EnsEMBL::Xref::Parser::ReactomeUniProtParser';
+
+my $parser = Bio::EnsEMBL::Xref::Parser::ReactomeUniProtParser->new(
+ source_id  => 85,
+ species_id => 9606,
+ files      => ["$Bin/test-data/uniprot_reactome.txt"],
+ xref_dba   => $xref_dba
+);
+
+isa_ok( $parser, 'Bio::EnsEMBL::Xref::Parser::ReactomeUniProtParser' );
+
+$parser->run();
+
+ok(
+ $db->schema->resultset('DependentXref')->fetch_dependent_xref("A0A075B6P5", "R-HSA-109582"),
+ 'Sample Reactome uniprot Xref has been inserted'
+);
+
+# Test if all the rows were inserted
+is($db->schema->resultset('Xref')->count, 8, "All 8 human rows were inserted");
+
+
+done_testing();
+

--- a/modules/t/test-data/ensembl_reactome.txt
+++ b/modules/t/test-data/ensembl_reactome.txt
@@ -1,0 +1,9 @@
+ENSG00000000419	R-HSA-162699	https://reactome.org/PathwayBrowser/#/R-HSA-162699	Synthesis of dolichyl-phosphate mannose	TAS	Homo sapiens
+ENSG00000000419	R-HSA-163125	https://reactome.org/PathwayBrowser/#/R-HSA-163125	Post-translational modification: synthesis of GPI-anchored proteins	TAS	Homo sapiens
+ENSG00000000419	R-HSA-1643685	https://reactome.org/PathwayBrowser/#/R-HSA-1643685	Disease	TAS	Homo sapiens
+ENSG00000000419	R-HSA-3781865	https://reactome.org/PathwayBrowser/#/R-HSA-3781865	Diseases of glycosylation	TAS	Homo sapiens
+ENSG00000000419	R-HSA-392499	https://reactome.org/PathwayBrowser/#/R-HSA-392499	Metabolism of proteins	TAS	Homo sapiens
+ENSG00000000419	R-HSA-446193	https://reactome.org/PathwayBrowser/#/R-HSA-446193	Biosynthesis of the N-glycan precursor (dolichol lipid-linked oligosaccharide, LLO) and transfer to a nascent protein	TAS	Homo sapiens
+ENSDARG00000000019	R-DRE-1280218	https://reactome.org/PathwayBrowser/#/R-DRE-1280218	Adaptive Immune System	IEA	Danio rerio
+ENSDARG00000000019	R-DRE-168256	https://reactome.org/PathwayBrowser/#/R-DRE-168256	Immune System	IEA	Danio rerio
+ENSDARG00000000019	R-DRE-392499	https://reactome.org/PathwayBrowser/#/R-DRE-392499	Metabolism of proteins	IEA	Danio rerio

--- a/modules/t/test-data/uniprot_reactome.txt
+++ b/modules/t/test-data/uniprot_reactome.txt
@@ -1,0 +1,10 @@
+A0A075B6P5	R-HSA-109582	https://reactome.org/PathwayBrowser/#/R-HSA-109582	Hemostasis	TAS	Homo sapiens
+A0A075B6P5	R-HSA-1280218	https://reactome.org/PathwayBrowser/#/R-HSA-1280218	Adaptive Immune System	TAS	Homo sapiens
+A0A075B6P5	R-HSA-1280218	https://reactome.org/PathwayBrowser/#/R-HSA-1280218	Adaptive Immune System	IEA	Homo sapiens
+A0A075B6P5	R-HSA-166658	https://reactome.org/PathwayBrowser/#/R-HSA-166658	Complement cascade	TAS	Homo sapiens
+A0A075B6P5	R-HSA-166663	https://reactome.org/PathwayBrowser/#/R-HSA-166663	Initial triggering of complement	TAS	Homo sapiens
+A0A075B6P5	R-HSA-166786	https://reactome.org/PathwayBrowser/#/R-HSA-166786	Creation of C4 and C2 activators	TAS	Homo sapiens
+A0A075B6P5	R-HSA-168249	https://reactome.org/PathwayBrowser/#/R-HSA-168249	Innate Immune System	TAS	Homo sapiens
+A0A075B6P5	R-HSA-168249	https://reactome.org/PathwayBrowser/#/R-HSA-168249	Innate Immune System	IEA	Homo sapiens
+A0A075B6P5	R-HSA-168256	https://reactome.org/PathwayBrowser/#/R-HSA-168256	Immune System	TAS	Homo sapiens
+A0A075B6P5	R-HSA-168256	https://reactome.org/PathwayBrowser/#/R-HSA-168256	Immune System	IEA	Homo sapiens

--- a/modules/t/test-data/uniprot_reactome.txt
+++ b/modules/t/test-data/uniprot_reactome.txt
@@ -8,3 +8,8 @@ A0A075B6P5	R-HSA-168249	https://reactome.org/PathwayBrowser/#/R-HSA-168249	Innat
 A0A075B6P5	R-HSA-168249	https://reactome.org/PathwayBrowser/#/R-HSA-168249	Innate Immune System	IEA	Homo sapiens
 A0A075B6P5	R-HSA-168256	https://reactome.org/PathwayBrowser/#/R-HSA-168256	Immune System	TAS	Homo sapiens
 A0A075B6P5	R-HSA-168256	https://reactome.org/PathwayBrowser/#/R-HSA-168256	Immune System	IEA	Homo sapiens
+A0A0A0MPA8	R-CFA-382551	https://reactome.org/PathwayBrowser/#/R-CFA-382551	Transport of small molecules	IEA	Canis familiaris
+A0A0A0MPA8	R-CFA-432047	https://reactome.org/PathwayBrowser/#/R-CFA-432047	Passive transport by Aquaporins	IEA	Canis familiaris
+A0A0A0MPA8	R-CFA-445717	https://reactome.org/PathwayBrowser/#/R-CFA-445717	Aquaporin-mediated transport	IEA	Canis familiaris
+A0A0A0MPA9	R-CFA-2672351	https://reactome.org/PathwayBrowser/#/R-CFA-2672351	Stimuli-sensing channels	IEA	Canis familiaris
+A0A0A0MPA9	R-CFA-382551	https://reactome.org/PathwayBrowser/#/R-CFA-382551	Transport of small molecules	IEA	Canis familiaris


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Two new parsers for Reactome data

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
Reactome data comes in two files, one for direct mappings to Ensembl stable IDs and one for mappings via UniProt accessions. This is done in two separate parsers

## Benefits

_If applicable, describe the advantages the changes will have._
Reactome data can be loaded in the xref pipeline

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
Reactome files have special characters which are not dealt with correctly by Text:CSV
Currently, this is avoided by removing problematic lines out of the file before running the parsers, which is less than ideal. A possible option would be to use Text::CSV::Encoded but this has not been tested yet

## Testing

_Have you added/modified unit tests to test the changes?_
Yes

_If so, do the tests pass/fail?_
Pass

_Have you run the entire test suite and no regression was detected?_
Yes

