### PR TITLE
ENSCORESW-2982: find files to test even if not running from root of r…

### DIFF
--- a/modules/t/perl_critic.t
+++ b/modules/t/perl_critic.t
@@ -27,6 +27,9 @@ limitations under the License.
 use strict;
 use warnings;
 
+use Cwd;
+use File::Spec;
+use File::Basename qw/dirname/;
 use Test::More;
 use Test::Warnings;
 
@@ -34,5 +37,14 @@ use Test::Perl::Critic (
     -severity => 3,
     -profile => '.perlcriticrc');
 
-all_critic_ok('modules/Bio');
+#chdir into the file's target & request cwd() which should be fully resolved now.
+##then go back
+my $file_dir = dirname(__FILE__);
+my $original_dir = cwd();
+chdir($file_dir);
+my $cur_dir = cwd();
+chdir($original_dir);
+my $root = File::Spec->catdir($cur_dir, File::Spec->updir(),File::Spec->updir());
+
+all_critic_ok("$root/modules/Bio");
 


### PR DESCRIPTION
…epository

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Allows to run perl critic even if not at the root of the repository

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
When running test cases, we can use absolute path. This change allows us to still run the perl critic test case in those situations

## Benefits

_If applicable, describe the advantages the changes will have._
Can run test cases from any directory

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
The test case is a bit longer

## Testing

_Have you added/modified unit tests to test the changes?_
Yes

_If so, do the tests pass/fail?_
Pass

_Have you run the entire test suite and no regression was detected?_
Yes

