### PR TITLE
Feature/mapper2baseadaptor

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
@@ -83,7 +83,6 @@ sub new {
     -PASS   => $args{pass} || '',
     -PORT => $args{port} || '3306'
   ) );
-
   $self->verbose( $args{verbose} // 0 );
 
   return $self;

--- a/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
@@ -53,6 +53,7 @@ use Getopt::Long;
 use IO::Uncompress::AnyUncompress;
 
 use Bio::EnsEMBL::DBSQL::DBConnection;
+use Bio::EnsEMBL::DBSQL::DBAdaptor;
 
 my $base_dir = File::Spec->curdir();
 
@@ -82,6 +83,7 @@ sub new {
     -PASS   => $args{pass} || '',
     -PORT => $args{port} || '3306'
   ) );
+
   $self->verbose( $args{verbose} // 0 );
 
   return $self;
@@ -115,6 +117,37 @@ sub dbi {
   return $self->dbc->db_handle;
 } ## end sub dbi
 
+
+=head2 dba
+  Description: Getter for the dba object
+  Return type: Bio::EnsEMBL::DBSQL::DBAdaptor instance
+  Caller     : internal
+=cut
+
+sub dba {
+    my $self = shift;
+    return Bio::EnsEMBL::DBSQL::DBAdaptor->new(-dbconn => $self->dbc, -species => $self->species);
+}
+
+
+=head2 species
+  Arg [1]    : (optional) string $arg
+               The new value of the species
+  Example    : $species = $dba->species()
+  Description: Getter/Setter for the current species
+  Returntype : string
+  Exceptions : none
+  Caller     : new
+=cut
+
+sub species{
+  my ($self, $arg) = @_;
+
+  if ( defined $arg ) {
+    $self->{_species} = $arg;
+  }
+  return $self->{_species};
+}
 
 
 =head2 get_filehandle

--- a/modules/t/baseadaptor.t
+++ b/modules/t/baseadaptor.t
@@ -537,6 +537,14 @@ is( _check_db( $db, 'PrimaryXref', { xref_id => $xref_id_new } )->sequence, 'CTA
 # _update_xref_description - This should have already been covered by previous tests
 # Specific tests can be added later
 
+# get/set_species
+ok( !defined($xref_dba->species), "Species not defined yet");
+is($xref_dba->species("human"), "human", "Species set to ". $xref_dba->species);
+
+# get_dba
+ok( defined($xref_dba->dba), "dba defined");
+isa_ok( $xref_dba->dba, 'Bio::EnsEMBL::DBSQL::DBAdaptor' );
+
 done_testing();
 
 


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Moved relevant methods (species and dba) from xref_mapping/XrefMapper/db.pm to new repo's BaseAdaptor

## Use case

BaseAdaptor already handles most of the db connection related routines. By moving/merging the methods from db, we try to reduce the redundancy

## Benefits

No need to maintain db.pm

## Possible Drawbacks

Have to update BaseMapper. Replace XrefMapper::db initialisation calls with BaseAdaptor initialisation

## Testing

Yes

_If so, do the tests pass/fail?_

Pass

