### PR TITLE
parser always runs with a database adaptor, no need for extra look ups

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/Parser/ArrayExpressParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/ArrayExpressParser.pm
@@ -109,7 +109,7 @@ sub run {
   $species_name = $species_id_to_names{$species_id}[0];
 
   #get stable_ids from core and create xrefs
-  my $gene_adaptor = $self->_get_gene_adaptor($project, $species_name, $dba);
+  my $gene_adaptor = $dba->get_GeneAdaptor();
 
   print "Finished loading the gene_adaptor\n" if $verbose;
 
@@ -141,48 +141,6 @@ sub run {
 
   return 0;      # successful
 
-}
-
-sub _get_gene_adaptor {
-  my ( $self, $project, $species_name, $dba ) = @_;
-
-  my $registry = "Bio::EnsEMBL::Registry";
-  
-  my ($gene_adaptor);
-
-  if ( defined $project && $project eq 'ensembl' ) {
-    $registry->load_registry_from_multiple_dbs(
-      {
-        '-host' => 'mysql-ens-sta-1',
-        '-port' => 4519,
-        '-user' => 'ensro',
-      },
-    );
-    $gene_adaptor = $registry->get_adaptor( $species_name, 'core', 'Gene' );
-  }
-  elsif ( defined $project && $project eq 'ensemblgenomes' ) {
-    $registry->load_registry_from_multiple_dbs(
-      {
-        '-host' => 'mysql-eg-staging-1.ebi.ac.uk',
-        '-port' => 4160,
-        '-user' => 'ensro',
-      },
-      {
-        '-host' => 'mysql-eg-staging-2.ebi.ac.uk',
-        '-port' => 4275,
-        '-user' => 'ensro',
-      },
-    );
-    $gene_adaptor = $registry->get_adaptor( $species_name, 'core', 'Gene' );
-  }
-  elsif ( defined $dba ) {
-    $gene_adaptor = $dba->get_GeneAdaptor();
-  }
-  else {
-    die( "Missing or unsupported project value. Supported values: ensembl, ensemblgenomes" );
-  }
-
-  return $gene_adaptor;
 }
 
 sub _get_species {


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
The old parser needed default host settings because there was no information about which database to use. In the eHive pipeline, the database to use is provided as an argument in the run method, hence it is not necessary to have an additional lookup. Additionally, the 'project' argument this relies on is never provided by the eHive pipeline

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
Remove deprecated code that is not used anywhere

## Benefits

_If applicable, describe the advantages the changes will have._
Code is simpler and more maintainable

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_
Test already exists and was not testing the removed functionality

_If so, do the tests pass/fail?_
Pass

_Have you run the entire test suite and no regression was detected?_
Yes

