### PR TITLE
Extend DB class to provide a populate_metadata method

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/DB.pm
+++ b/modules/Bio/EnsEMBL/Xref/DB.pm
@@ -101,7 +101,7 @@ has now_function => (
 
 sub _init_db {
   my $self = shift;
-  carp "Setting up schema\n";
+
   $self->_init_config if ! defined $self->config;
   $self->_validate_config($self->config);
   my %conf = %{ $self->config };
@@ -119,7 +119,6 @@ sub _init_db {
 
   my %deploy_opts = ();
   # Example deploy option $deploy_opts{add_drop_table} = 1;
-  carp 'Connecting: '.$dsn."\n";
   my $schema = Bio::EnsEMBL::Xref::Schema->connect($dsn, $conf{user}, $conf{pass}, \%opts);
 
   if ($conf{create} == 1 && $conf{driver} eq 'mysql') {

--- a/modules/Bio/EnsEMBL/Xref/DB.pm
+++ b/modules/Bio/EnsEMBL/Xref/DB.pm
@@ -450,6 +450,18 @@ sub _load_xref_config {
   return $config;
 }
 
+=head2 _mangle_source_block
+
+Arg 1      : String - section header, the name for the section that identifies
+                      the section we need to extract values from
+Arg 2      : Hashref - config file content, the output of _load_xref_config()
+Description: Takes a single source record from xref_config.ini and creates a
+             hashref. Some arguments are massaged to get them into the schema
+             easily
+Returntype : Hashref of a single source's properties
+Caller     : Internal
+
+=cut
 
 sub _mangle_source_block {
   my ($self, $section, $config) = @_;

--- a/modules/Bio/EnsEMBL/Xref/DB.pm
+++ b/modules/Bio/EnsEMBL/Xref/DB.pm
@@ -114,16 +114,18 @@ sub _init_db {
     $dsn = sprintf 'dbi:%s:database=%s',$conf{driver},$conf{file};
     $self->now_function("date('now')");
   } else {
-    $dsn = sprintf 'dbi:%s:database=%s;host=%s;port=%s',$conf{driver},$conf{db},$conf{host},$conf{port};
+    $dsn = sprintf 'dbi:%s:database=%s;host=%s;port=%s', $conf{driver}, $conf{db}, $conf{host}, $conf{port};
   }
 
   my %deploy_opts = ();
   # Example deploy option $deploy_opts{add_drop_table} = 1;
   carp 'Connecting: '.$dsn."\n";
-  my $schema = Bio::EnsEMBL::Xref::Schema->connect($dsn, $conf{user},$conf{pass}, \%opts);
+  my $schema = Bio::EnsEMBL::Xref::Schema->connect($dsn, $conf{user}, $conf{pass}, \%opts);
 
   if ($conf{create} == 1 && $conf{driver} eq 'mysql') {
-    my $dbh = DBI->connect(sprintf('DBI:%s:database=;host=%s;port=%s',$conf{driver},$conf{host},$conf{port}),$conf{user},$conf{pass}, \%opts);
+    my $dbh = DBI->connect(
+      sprintf('DBI:%s:database=;host=%s;port=%s', $conf{driver}, $conf{host}, $conf{port}), $conf{user}, $conf{pass}, \%opts
+    );
     $dbh->do('CREATE DATABASE '.$conf{db}.';');
     $dbh->disconnect;
   }

--- a/modules/Bio/EnsEMBL/Xref/Schema/Result/DependentSource.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/Result/DependentSource.pm
@@ -48,6 +48,7 @@ __PACKAGE__->table("dependent_source");
 
   data_type: 'varchar'
   is_nullable: 0
+  description: Name of the source that must be imported before this source can be processed
   size: 255
 
 =cut
@@ -74,8 +75,8 @@ __PACKAGE__->add_columns(
 =cut
 
 __PACKAGE__->set_primary_key('dependent_relation_id');
-__PACKAGE__->add_unique_constraint("master_source_id", ["dependent_name"]);
+# __PACKAGE__->add_unique_constraint("master_source_id", ["dependent_name"]);
 
-__PACKAGE__->has_one('master_source', 'Bio::EnsEMBL::Xref::Schema::Result::Source', { 'foreign.source_id' => 'self.master_source_id' } );
+__PACKAGE__->belongs_to('master_source', 'Bio::EnsEMBL::Xref::Schema::Result::Source', { 'foreign.source_id' => 'self.master_source_id' } );
 
 1;

--- a/modules/Bio/EnsEMBL/Xref/Schema/Result/Source.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/Result/Source.pm
@@ -71,12 +71,6 @@ __PACKAGE__->table("source");
   extra: {list => ["Y","N"]}
   is_nullable: 1
 
-=head2 ordered
-
-  data_type: 'integer'
-  extra: {unsigned => 1}
-  is_nullable: 0
-
 =head2 priority
 
   data_type: 'integer'
@@ -121,8 +115,6 @@ __PACKAGE__->add_columns(
     extra => { list => ["Y", "N"] },
     is_nullable => 1,
   },
-  "ordered",
-  { data_type => "integer", extra => { unsigned => 1 }, is_nullable => 0 },
   "priority",
   {
     data_type => "integer",
@@ -144,7 +136,18 @@ __PACKAGE__->add_columns(
 
 =cut
 
-__PACKAGE__->set_primary_key("source_id");
+__PACKAGE__->set_primary_key('source_id');
 
 __PACKAGE__->has_many('xrefs', 'Bio::EnsEMBL::Xref::Schema::Result::Xref', 'source_id');
+__PACKAGE__->might_have(
+  'dependent_source',
+  'Bio::EnsEMBL::Xref::Schema::Result::DependentSource',
+  { 'foreign.master_source_id' => 'self.source_id' }
+);
+__PACKAGE__->might_have(
+  'source_url',
+  'Bio::EnsEMBL::Xref::Schema::Result::SourceUrl',
+  { 'foreign.source_id' => 'self.source_id' }
+);
+
 1;

--- a/modules/Bio/EnsEMBL/Xref/Schema/Result/SourceUrl.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/Result/SourceUrl.pm
@@ -140,4 +140,5 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("source_url_id");
 
 __PACKAGE__->has_one('source', 'Bio::EnsEMBL::Xref::Schema::Result::Source', 'source_id' );
+__PACKAGE__->has_one('species', 'Bio::EnsEMBL::Xref::Schema::Result::Species', 'species_id' );
 1;

--- a/modules/Bio/EnsEMBL/Xref/Schema/Result/Species.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/Result/Species.pm
@@ -66,7 +66,7 @@ __PACKAGE__->table("species");
 
 __PACKAGE__->add_columns(
   "species_id",
-  { data_type => "integer", extra => { unsigned => 1 }, is_nullable => 0 },
+  { data_type => "integer", extra => { unsigned => 1 }, is_nullable => 0, is_auto_increment => 1 },
   "taxonomy_id",
   { data_type => "integer", extra => { unsigned => 1 }, is_nullable => 0 },
   "name",
@@ -88,7 +88,8 @@ __PACKAGE__->add_columns(
 =back
 
 =cut
-
-__PACKAGE__->add_unique_constraint("species_taxonomy_idx", ["species_id", "taxonomy_id"]);
+__PACKAGE__->set_primary_key('species_id');
+__PACKAGE__->add_unique_constraint('species_taxonomy_idx', ['taxonomy_id']);
+__PACKAGE__->has_many('source_url', 'Bio::EnsEMBL::Xref::Schema::Result::SourceUrl', 'source_id');
 
 1;

--- a/modules/t/test-data/xref_config.ini
+++ b/modules/t/test-data/xref_config.ini
@@ -1,0 +1,549 @@
+# $Id$
+
+##########################################################################
+# SOURCES                                                                #
+#                                                                        #
+# Keys:                                                                  #
+#   name          - name of this source (required)                       #
+#   priority      - priority of these data files when more files belong  #
+#                   to the same source 'name'                            #
+#   prio_descr    - label for the 'priority'                             #
+#   parser        - the parser to be used (required)                     #
+#                                                                        #
+##########################################################################
+
+[source RNACentral::MULTI]
+name        = RNAcentral
+parser      = ChecksumParser
+
+[source UniParc::MULTI]
+name        = UniParc
+parser      = ChecksumParser
+
+[source ArrayExpress::MULTI]
+# Used by all species
+name            = ArrayExpress
+parser          = ArrayExpressParser
+
+[source EntrezGene::MULTI]
+# Used by all species
+name            = EntrezGene
+parser          = EntrezGeneParser
+
+[source WikiGene::MULTI]
+# used via the EntrezGeneParser, for all species
+name            = WikiGene
+parser          = EntrezGeneParser
+
+[source Reactome_gene::MULTI]
+# Used by all species
+name            = Reactome_gene
+parser          = ReactomeDirectParser
+
+[source Reactome_transcript::MULTI]
+# Species source used in ReactomeParser. No species uses this source
+name            = Reactome_transcript
+parser          = ReactomeParser
+
+[source Reactome_translation::MULTI]
+# Used by all species
+name            = Reactome_translation
+parser          = ReactomeUniProtParser
+
+[source RFAM::MULTI]
+# Used by all species
+name            = RFAM
+parser          = RFAMParser
+
+[source miRBase::MULTI]
+# Used by all species
+name            = miRBase
+parser          = miRBaseParser
+
+[source RefSeq_dna::MULTI-vertebrate]
+# Used by vertebrates
+name            = RefSeq_dna
+priority        = 2
+prio_descr      = refseq
+parser          = RefSeqGPFFParser
+
+[source RefSeq_mRNA::MULTI]
+# Special source used in RefSeqParser.  No species uses this source.
+name            = RefSeq_mRNA
+priority        = 2
+prio_descr      = refseq
+parser          = RefSeqParser
+
+[source RefSeq_mRNA_predicted::MULTI]
+# Special source used in RefSeqParser.  No species uses this source.
+name            = RefSeq_mRNA_predicted
+priority        = 2
+prio_descr      = refseq
+parser          = RefSeqParser
+
+[source RefSeq_peptide::MULTI-vertebrate]
+# Used by vertebrates
+name            = RefSeq_peptide
+priority        = 2
+prio_descr      = refseq
+parser          = RefSeqGPFFParser
+
+[source RefSeq_peptide_predicted::MULTI-vertebrate]
+# Used by vertebrates
+name            = RefSeq_peptide_predicted
+priority        = 2
+prio_descr      = refseq
+parser          = RefSeqGPFFParser
+
+[source RefSeq_ncRNA::MULTI]
+# Special source used in RefSeqParser.  No species uses this source.
+name            = RefSeq_ncRNA
+priority        = 1
+prio_descr      = refseq
+parser          = RefSeqParser
+
+[source RefSeq_ncRNA_predicted::MULTI]
+# Special source used in RefSeqParser.  No species uses this source.
+name            = RefSeq_ncRNA_predicted
+priority        = 1
+prio_descr      = refseq
+parser          = RefSeqParser
+
+[source RefSeq_import::otherfeatures]
+# Import RefSeq models from otherfeatures database
+name            = RefSeq_import
+priority        = 1
+prio_descr      = otherfeatures
+parser          = RefSeqCoordinateParser
+
+[source RefSeq_mRNA::otherfeatures]
+# Special source used in RefSeqCoordinateParser.  No species uses this source.
+name            = RefSeq_mRNA
+priority        = 1
+prio_descr      = otherfeatures
+parser          = RefSeqCoordinateParser
+
+[source RefSeq_peptide::otherfeatures]
+# Special source used in RefSeqCoordinateParser.  No species uses this source.
+name            = RefSeq_peptide
+priority        = 1
+prio_descr      = otherfeatures
+parser          = RefSeqCoordinateParser
+
+[source RefSeq_mRNA_predicted::otherfeatures]
+# Special source used in RefSeqCoordinateParser.  No species uses this source.
+name            = RefSeq_mRNA_predicted
+priority        = 1
+prio_descr      = otherfeatures
+parser          = RefSeqCoordinateParser
+
+[source RefSeq_peptide_predicted::otherfeatures]
+# Special source used in RefSeqCoordinateParser.  No species uses this source.
+name            = RefSeq_peptide_predicted
+priority        = 1
+prio_descr      = otherfeatures
+parser          = RefSeqCoordinateParser
+
+[source RefSeq_ncRNA::otherfeatures]
+# Special source used in RefSeqCoordinateParser.  No species uses this source.
+name            = RefSeq_ncRNA
+priority        = 1
+prio_descr      = otherfeatures
+parser          = RefSeqCoordinateParser
+
+[source RefSeq_ncRNA_predicted::otherfeatures]
+# Special source used in RefSeqCoordinateParser.  No species uses this source.
+name            = RefSeq_ncRNA_predicted
+priority        = 1
+prio_descr      = otherfeatures
+parser          = RefSeqCoordinateParser
+
+[source Uniprot/SPTREMBL::MULTI]
+# Used by all species
+name            = Uniprot/SPTREMBL
+priority        = 3
+prio_descr      = sequence_mapped
+parser          = UniProtParser
+
+[source Uniprot/SWISSPROT::MULTI]
+# Used by all species
+name            = Uniprot/SWISSPROT
+priority        = 3
+prio_descr      = sequence_mapped
+parser          = UniProtParser
+
+[source UCSC::MULTI]
+# Special source used in UCSCParser.  No species uses this source.
+name            = UCSC
+parser          = UCSCParser
+
+[source UCSC::homo_sapiens]
+# Used by homo_sapiens
+name            = UCSC_hg38
+parser          = UCSC_human_parser
+
+[source UCSC::mus_musculus]
+# Used by mus_musculus
+name            = UCSC_mm10
+parser          = UCSC_mouse_parser
+
+[source Uniprot/SPTREMBL::MULTI-evidence_gt_2]
+# Additional source for entries with evidence at protein level > 2 (numerically) for Uniprot/SPTREMBL::MULTI
+# These are not taken into account when deriving display xrefs or assigning gene status
+name            = Uniprot/SPTREMBL
+priority        = 10
+prio_descr      = protein_evidence_gt_2
+parser          = UniProtParser
+
+[source Uniprot/SWISSPROT::DIRECT]
+# Special source used in UniProtParser for direct mappings from Uniprot
+name            = Uniprot/SWISSPROT
+priority        = 1
+prio_descr      = direct
+parser          = UniProtParser
+
+[source Uniprot/SPTREMBL::DIRECT]
+# Special source used in UniProtParser for direct mappings from Uniprot
+name            = Uniprot/SPTREMBL
+priority        = 1
+prio_descr      = direct
+parser          = UniProtParser
+
+[source Uniprot_gn]
+# Special source used in UniProtParser for gene names..
+name            = Uniprot_gn
+parser          = UniProtParser
+
+[source UniProt::protein_id]
+# Special source used in UniProtParser.  No species uses this source.
+name            = protein_id
+parser          = UniProtParser
+
+[source UniProt::PDB]
+# Special source used in UniProtParser.  No species uses this source.
+name            = PDB
+parser          = UniProtParser
+
+[source UniProt::MEROPS]
+# Special source used in UniProtParser.  No species uses this source.
+name            = MEROPS
+parser          = UniProtParser
+
+[source UniProt::EMBL]
+# Special source used in UniProtParser.  No species uses this source.
+name            = EMBL
+parser          = UniProtParser
+
+[source UniProt::ChEMBL]
+# Special source used in UniProtParser.  No species uses this source.
+name            = ChEMBL
+parser          = UniProtParser
+
+[source Xenopus_Jamboree::xenopus_tropicalis]
+# Used by xenopus_tropicalis
+name            = Xenbase
+parser          = XenopusJamboreeParser
+
+[source ZFIN_ID::danio_rerio#01]
+# Used by danio_rerio
+name            = ZFIN_ID
+parser          = ZFINParser
+
+[source ZFIN_ID::danio_rerio#02]
+# Used by danio_rerio
+name            = ZFIN_ID
+parser          = ZFINDescParser
+
+[source cint_aniseed_v1::ciona_intestinalis]
+# Used by ciona_intestinalis
+name            = cint_aniseed_v1
+parser          = JGI_ProteinParser
+
+[source cint_jgi_v1::ciona_intestinalis]
+# Used by ciona_intestinalis
+name            = cint_jgi_v1
+parser          = JGI_ProteinParser
+
+[source VGNC::pan_troglodytes]
+# Used by pan_troglodytes
+name            = VGNC
+parser          = VGNCParser
+
+[source VGNC::bos_taurus]
+# Used by bos_taurus
+name            = VGNC
+parser          = VGNCParser
+
+[source VGNC::canis_familiaris]
+# Used by canis_familiaris
+name            = VGNC
+parser          = VGNCParser
+
+[source VGNC::equus_caballus]
+# Used by equus_caballus
+name            = VGNC
+parser          = VGNCParser
+
+[source CCDS::homo_sapiens]
+# Used by homo_sapiens
+name            = CCDS
+parser          = CCDSParser
+
+[source CCDS::mus_musculus]
+# Used by mus_musculus
+name            = CCDS
+parser          = CCDSParser
+
+[source DBASS5::homo_sapiens]
+# Used by homo_sapiens
+name            = DBASS5
+parser          = DBASSParser
+
+[source DBASS3::homo_sapiens]
+# Used by homo_sapiens
+name            = DBASS3
+parser          = DBASSParser
+
+[source HPA::homo_sapiens]
+# Used by homo_sapiens
+name            = HPA
+parser          = HPAParser
+
+[source MIM_GENE::homo_sapiens]
+# MIM parse loads data as MIM_GENE or MIM_MORBID not as MIM
+name            = MIM_GENE
+parser          = MIMParser
+
+[source MIM_MORBID::homo_sapiens]
+# MIM parse loads data as MIM_GENE or MIM_MORBID not as MIM
+name            = MIM_MORBID
+parser          = MIMParser
+
+[source MIM::homo_sapiens]
+# Used by homo_sapiens
+name            = MIM
+parser          = MIMParser
+
+[source MIM2GENE::homo_sapiens]
+# Used by homo_sapiens
+name            = MIM2GENE
+parser          = Mim2GeneParser
+
+[source MGI::mus_musculus#03]
+# Used by mus_musculus
+name            = MGI
+priority        = 4
+prio_descr      = uniprot
+
+[source MGI::mus_musculus#01]
+# Used by mus_musculus
+name            = MGI
+priority        = 1
+prio_descr      = official
+parser          = MGIParser
+
+[source MGI::mus_musculus#02]
+# Used by mus_musculus
+name            = MGI
+priority        = 10
+prio_descr      = descriptions
+parser          = MGI_Desc_Parser
+
+[source RGD::rattus_norvegicus]
+# Used by rattus_norvegicus
+name            = RGD
+priority        = 2
+parser          = RGDParser
+
+[source RGD::rattus_norvegicus#01]
+# Used by rattus_norvegicus
+name            = RGD
+priority        = 1
+prio_descr      = direct_xref
+parser          = done_in_RGDParser
+
+[source HGNC::homo_sapiens]
+# Used by homo_sapiens
+name            = HGNC
+priority        = 4
+prio_descr      = entrezgene_manual
+parser          = HGNCParser
+
+[source HGNC::homo_sapiens#01]
+# Used by #02
+name            = HGNC
+priority        = 5
+prio_descr      = refseq_manual
+parser          = HGNCParser
+
+[source HGNC::homo_sapiens#02]
+# used by #02
+name            = HGNC
+priority        = 1
+prio_descr      = ensembl_manual
+parser          = HGNCParser
+
+[source HGNC::homo_sapiens#03]
+# used by #02
+name            = HGNC
+priority        = 2
+prio_descr      = ccds
+parser          = HGNCParser
+
+[source HGNC::homo_sapiens#04]
+# used by #02
+name            = HGNC
+priority        = 100
+prio_descr      = desc_only
+parser          = HGNCParser
+
+[source LRG_HGNC_notransfer]
+name            = LRG_HGNC_notransfer
+priority        = 50
+parser          = HGNCParser
+
+[source miRBase_trans_name]
+# Used homo_sapiens,mus_musculus
+name            = miRBase_trans_name
+parser          = comes via official naming
+
+[source ZFIN_ID_trans_name]
+name            = ZFIN_ID_trans_name
+parser          = done_in_official_naming
+
+[source PIGGY_trans_name]
+name            = PIGGY_trans_name
+parser          = done_in_official_naming
+
+[source HGNC_trans_name]
+name            = HGNC_trans_name
+parser          = done_in_official_naming
+
+[source VGNC_trans_name]
+name            = VGNC_trans_name
+parser          = done_in_official_naming
+
+[source MGI_automatic_transcript::mus_musculus]
+name            = MGI_automatic_transcript_notransfer
+parser          = done_in_official_naming
+
+[source MGI_trans_name]
+# Used homo_sapiens,mus_musculus
+name            = MGI_trans_name
+parser          = comes via official naming
+
+[source Clone_based_ensembl_transcript::homo_sapiens]
+name            = Clone_based_ensembl_transcript
+parser          = done_in_official_naming
+
+[source Clone_based_ensembl_gene::homo_sapiens]
+name            = Clone_based_ensembl_gene
+parser          = done_in_official_naming
+
+[source RFAM_trans_name]
+# Used homo_sapiens,mus_musculus
+name            = RFAM_trans_name
+parser          = comes via official naming
+
+[source Uniprot_gn_trans_name]
+# Used by merged species: homo_sapiens,mus_musculus, danio_rerio and sus_scrofa
+name            = Uniprot_gn_trans_name
+parser          = comes via official naming
+
+[source EntrezGene_trans_name]
+# Used by all species
+name            = EntrezGene_trans_name
+parser          = comes via official naming
+
+[source RGD_trans_name]
+name            = RGD_trans_name
+parser          = done_in_official_naming
+
+
+########################################################################
+# SPECIES                                                              #
+#                                                                      #
+# Keys:                                                                #
+#   taxonomy_id - taxonomy ID of species/strain (multiple, required)   #
+#   source      - sources used for this species/strain                 #
+#                 (multiple, required)                                 #
+#                                                                      #
+########################################################################
+
+########################################################################
+# VERTEBRATES                                                          #
+#                                                                      #
+# Default sources for vertebrates                                      #
+# Additional configuration for species-specific sources                #
+#                                                                      #
+########################################################################
+
+[species vertebrates]
+taxonomy_id     = 7742
+source          = EntrezGene::MULTI
+source          = Reactome_gene::MULTI
+source          = Reactome_translation::MULTI
+source          = RNACentral::MULTI
+source          = RefSeq_dna::MULTI-vertebrate
+source          = RefSeq_peptide::MULTI-vertebrate
+source          = RefSeq_import::otherfeatures
+source          = Uniprot/SPTREMBL::MULTI
+source          = Uniprot/SWISSPROT::MULTI
+source          = UniParc::MULTI
+source          = RFAM::MULTI
+source          = miRBase::MULTI
+source          = ArrayExpress::MULTI
+
+[species homo_sapiens]
+taxonomy_id     = 9606
+source          = CCDS::homo_sapiens
+source          = DBASS3::homo_sapiens
+source          = DBASS5::homo_sapiens
+source          = HPA::homo_sapiens
+source          = HGNC::homo_sapiens
+source          = MIM::homo_sapiens
+source          = MIM2GENE::homo_sapiens
+source          = UCSC::homo_sapiens
+
+[species mus_musculus]
+taxonomy_id     = 10090
+source          = CCDS::mus_musculus
+source          = EntrezGene::MULTI
+source          = MGI::mus_musculus#01
+source          = MGI::mus_musculus#02
+source          = UCSC::mus_musculus
+
+[species danio_rerio]
+taxonomy_id     = 7955
+source          = ZFIN_ID::danio_rerio#01
+source          = ZFIN_ID::danio_rerio#02
+
+[species rattus_norvegicus]
+taxonomy_id     = 10116
+source          = RGD::rattus_norvegicus
+
+[species bos_taurus]
+taxonomy_id     = 9913
+source          = VGNC::bos_taurus
+
+[species canis_familiaris]
+taxonomy_id     = 9615
+source          = VGNC::canis_familiaris
+
+[species equus_caballus]
+taxonomy_id     = 9796
+source          = VGNC::equus_caballus
+
+[species pan_troglodytes]
+taxonomy_id     = 9598
+source          = VGNC::pan_troglodytes
+
+[species ciona_intestinalis]
+taxonomy_id     = 7719
+source          = cint_aniseed_v1::ciona_intestinalis
+source          = cint_jgi_v1::ciona_intestinalis
+
+[species xenopus_tropicalis]
+taxonomy_id     = 8364
+source          = Xenopus_Jamboree::xenopus_tropicalis
+

--- a/modules/t/testdb.t
+++ b/modules/t/testdb.t
@@ -93,6 +93,16 @@ my $result = $db->schema->resultset('Source')->find(
 is($result->download, 'Y', 'All VGNC sources are downloaded');
 is($result->status, 'NOIDEA', 'All VGNC sources have the same status');
 
+# We do not use URLs in the current pipeline, so it's difficult and fruitless to test
+# the source_url relationship
+
+my @species = $db->schema->resultset('Species')->search();
+is_deeply(
+  [map {$_->name} @species],
+  [qw/ciona_intestinalis vertebrates danio_rerio xenopus_tropicalis
+      pan_troglodytes homo_sapiens canis_familiaris equus_caballus 
+      bos_taurus mus_musculus rattus_norvegicus/],
+  'Species names were all stored');
 
 
 done_testing;


### PR DESCRIPTION
## Description

Extend DB class to provide a populate_metadata method which can xref_config.ini files. Additional relationships added to DBIC classes to support create_related use.

## Use case

Pipeline still uses a core script to load metadata, this can happen directly without shelling out

## Benefits

Removes dependencies, code is much tighter for consuming xref_config.ini

## Possible Drawbacks

Won't necessarily work with EG species not present in the test config file

## Testing

Simple unit tests added to ensure something was loaded into the relevant tables

_Have you run the entire test suite and no regression was detected?_

No interactions with other tests