### PR TITLE
RFAM parser derived from work on older branch.

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Xref/DBSQL/BaseAdaptor.pm
@@ -50,7 +50,7 @@ use Carp;
 use Bio::EnsEMBL::Utils::Exception;
 use Bio::EnsEMBL::Xref::FetchFiles;
 use Getopt::Long;
-use IO::Uncompress::AnyUncompress;
+use IO::Uncompress::AnyUncompress '$AnyUncompressError';
 
 use Bio::EnsEMBL::DBSQL::DBConnection;
 use Bio::EnsEMBL::DBSQL::DBAdaptor;
@@ -187,7 +187,7 @@ sub get_filehandle {
   # It should be on by default but set it just in case.
   $io = IO::Uncompress::AnyUncompress->new($file_name,
                                            'Transparent' => 1 )
-    || confess("Can not open file '$file_name'");
+    || confess("Can not open file '$file_name' because: $AnyUncompressError");
 
   if ($verbose) {
     print "Reading from '$file_name'...\n";

--- a/modules/Bio/EnsEMBL/Xref/Parser/RFAMParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/RFAMParser.pm
@@ -114,6 +114,7 @@ sub run {
       }
     }
   }
+  return 0;
 }
 
 =head2 parse_stockholm_format

--- a/modules/Bio/EnsEMBL/Xref/Parser/RFAMParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/RFAMParser.pm
@@ -63,6 +63,15 @@ use Carp;
 
 use parent 'Bio::EnsEMBL::Xref::Parser';
 
+=head2 run
+
+Description: Reimplements Bio::EnsEMBL::Xref::Parser::run . Requires source_id,
+             species_id, a list containing the Rfam seed file, and database
+             adaptors for core DB and xref DB
+Caller     : Xref pipeline ParseSource
+
+=cut
+
 sub run {
   my ( $self ) = @_;
   my $source_id    = $self->{source_id};

--- a/modules/Bio/EnsEMBL/Xref/Parser/RFAMParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/RFAMParser.pm
@@ -1,0 +1,202 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+=head1 CONTACT
+
+  Please email comments or questions to the public Ensembl
+  developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+  Questions may also be sent to the Ensembl help desk at
+  <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Xref::Parser::RFAMParser
+
+=head1 DESCRIPTION
+
+A parser class to parse the RFAM seed files in Stockholm format.
+
+It mostly throws away the content, we use it solely as an authoritative list
+of valid RFAM IDs and their description. We then rely on the Genebuild 
+alignments of RFAM sequences to decide which Xrefs to create.
+
+Can apply to all ensembl species but does not. Core DB must contain relevant
+data, so many non-vertebrates are excluded.
+
+=head1 SYNOPSIS
+
+  my $parser = Bio::EnsEMBL::Xref::Parser::RFAMParser->new(
+    source_id  => 1,
+    species_id => 9606,
+    files => [$path.'Rfam.seed.gz']
+    xref_dba   => $xref_dba,  # xref db adaptor
+    core_dba   => $dba   # core db adaptor
+  );
+
+  $parser->run();
+=cut
+
+
+package Bio::EnsEMBL::Xref::Parser::RFAMParser;
+
+use strict;
+use warnings;
+use Carp;
+
+use parent 'Bio::EnsEMBL::Xref::Parser';
+
+sub run {
+  my ( $self ) = @_;
+  my $source_id    = $self->{source_id};
+  my $species_id   = $self->{species_id};
+  my $files        = $self->{files};
+  my $xref_dba     = $self->{xref_dba};
+  my $core_dba     = $self->{dba};
+
+  my $file = shift @$files;
+
+  my $analysis_adaptor = $core_dba->get_AnalysisAdaptor();
+
+  my $rfam_analysis = $analysis_adaptor->fetch_by_logic_name('rfamblast');
+
+  # RFAM IDs are not present for all species. If Genebuild have not run the 
+  # analysis, skip this species
+  return 0 if ! defined $rfam_analysis;
+
+  my @complete_meta = @{ $self->parse_stockholm_format($file) };
+
+  # Iterate through all RFAM records
+  my %supporting_features = %{ $self->get_rfam_supporting_features($core_dba) };
+
+  # Now insert any matches as xrefs with direct links to Transcript IDs
+  # referenced by supporting features
+  foreach my $rfam (@complete_meta) {
+    if ( exists $supporting_features{ $rfam->{AC} } ) {
+      my $xref_id = $xref_dba->add_xref({
+        acc => $rfam->{AC},
+        version => 1,
+        label => $rfam->{ID},
+        desc => $rfam->{DE},
+        source_id => $source_id,
+        species_id => $species_id,
+        info_type => 'DIRECT'
+      });
+
+      foreach my $stable_id ( @{ $supporting_features{ $rfam->{AC}} }) {
+        $xref_dba->add_direct_xref($xref_id, $stable_id, 'Transcript');
+      }
+    }
+  }
+}
+
+=head2 parse_stockholm_format
+
+Arg 1      :  File path
+Description:  Extracts all the metadata from an RFAM file
+              We completely ignore all the alignments
+Returntype :  Arrayref of hashrefs containing RFAM metadata
+
+=cut
+
+sub parse_stockholm_format {
+  my ($self,$file_path) = @_;
+
+  my %rfam_ids = ();
+  # It's not a big file, we can do this in a single hit
+  my $fh = $self->{xref_dba}->get_filehandle($file_path);
+  local $/ = '//';
+
+  my @complete_meta;
+  while (my $record = <$fh>) {
+
+    my %meta = $record =~/
+      ^
+      \#=GF\s+  # All meta keys start with #=GF
+      (\w\w)    # Two letter code for meaning of key
+      \s+
+      (.+)      # Meta fields sometimes contain spaces
+      $
+    /mgx;
+
+    unless ( exists $meta{AC} && exists $meta{ID} && exists $meta{DE}) {
+      warn 'Skipping an incompletely annotated record in '.$file_path;
+      next;
+    }
+
+    push @complete_meta, \%meta;
+  }
+ 
+  return \@complete_meta;
+}
+
+=head2 get_rfam_supporting_features
+
+Arg 1      : $dba - a core DBAdaptor
+Description: Access a core DB and retrieve DnaAlignFeatures with the correct
+             ncRNA logic name, and match them up with transcript stable IDs
+             This could perhaps be achieved through the core API, but it will
+             be cumbersome unless we extend the TranscriptSupportingFeatureAdaptor
+             for this specific purpose
+Returntype : Hashref of listrefs - RFAM Ids and their Ensembl transcript ID pairings
+
+=cut
+
+sub get_rfam_supporting_features {
+  my ($self,$dba) = @_;
+
+  my $rfam_sql = q(
+    SELECT DISTINCT t.stable_id, hit_name 
+    FROM analysis a
+    JOIN transcript t
+      ON (
+            a.analysis_id = t.analysis_id
+        AND a.logic_name = 'ncRNA'
+        AND t.biotype != 'miRNA'
+      )
+    JOIN exon_transcript et
+      ON (
+        t.transcript_id = et.transcript_id
+      )
+    JOIN supporting_feature sf
+      ON (
+            et.exon_id = sf.exon_id
+        AND sf.feature_type = 'dna_align_feature' 
+      )
+    JOIN dna_align_feature df
+      ON (
+        sf.feature_id = df.dna_align_feature_id
+      )
+    ORDER BY hit_name
+  );
+
+  my $iterator = $dba->dbc->sql_helper()->execute(-SQL => $rfam_sql, -ITERATOR => 1);
+  my %rfam_mapping;
+  while ($iterator->has_next()) {
+    my $row = $iterator->next;
+    # RFAM sequences align to 1+ transcripts
+    if ($row->[1] =~ /^RF\d+/) {
+      push @{ $rfam_mapping{$row->[1]} }, $row->[0];
+    }
+  }
+  return \%rfam_mapping;
+}
+
+1;

--- a/modules/t/rfam.t
+++ b/modules/t/rfam.t
@@ -50,7 +50,7 @@ my $xref_dba = Bio::EnsEMBL::Xref::DBSQL::BaseAdaptor->new(
 my $core_test_db = Bio::EnsEMBL::Test::MultiTestDB->new();
 my $core_dba = $core_test_db->get_DBAdaptor('core');
 
-my $test_file = File::Spec->catfile($Bin,'test-data','Rfam.seed');
+my $test_file = File::Spec->catfile($Bin,'test-data','rfam.seed');
 
 my $parser = Bio::EnsEMBL::Xref::Parser::RFAMParser->new(
   source_id => 1,

--- a/modules/t/rfam.t
+++ b/modules/t/rfam.t
@@ -50,7 +50,7 @@ my $xref_dba = Bio::EnsEMBL::Xref::DBSQL::BaseAdaptor->new(
 my $core_test_db = Bio::EnsEMBL::Test::MultiTestDB->new();
 my $core_dba = $core_test_db->get_DBAdaptor('core');
 
-my $test_file = File::Spec->catfile($Bin,'test-data','Rfam.seed.gz');
+my $test_file = File::Spec->catfile($Bin,'test-data','Rfam.seed');
 
 my $parser = Bio::EnsEMBL::Xref::Parser::RFAMParser->new(
   source_id => 1,

--- a/modules/t/rfam.t
+++ b/modules/t/rfam.t
@@ -1,0 +1,204 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin '$Bin';
+use File::Spec;
+
+use Bio::EnsEMBL::Test::MultiTestDB;
+use Bio::EnsEMBL::Xref::Parser::RFAMParser;
+
+use Bio::EnsEMBL::Xref::Test::TestDB;
+use Bio::EnsEMBL::Xref::DBSQL::BaseAdaptor;
+
+use Bio::EnsEMBL::Gene;
+use Bio::EnsEMBL::Transcript;
+use Bio::EnsEMBL::Exon;
+use Bio::EnsEMBL::DnaDnaAlignFeature;
+use Bio::EnsEMBL::Analysis;
+
+use_ok 'Bio::EnsEMBL::Xref::Parser';
+
+my $test_db     = Bio::EnsEMBL::Xref::Test::TestDB->new();
+my %config = %{ $test_db->config };
+
+my $xref_dba = Bio::EnsEMBL::Xref::DBSQL::BaseAdaptor->new(
+    host   => $config{host},
+    dbname => $config{db},
+    user   => $config{user},
+    pass   => $config{pass},
+    port   => $config{port}
+);
+
+my $core_test_db = Bio::EnsEMBL::Test::MultiTestDB->new();
+my $core_dba = $core_test_db->get_DBAdaptor('core');
+
+my $test_file = File::Spec->catfile($Bin,'test-data','Rfam.seed.gz');
+
+my $parser = Bio::EnsEMBL::Xref::Parser::RFAMParser->new(
+  source_id => 1,
+  species_id => 1,
+  files => [$test_file],
+  xref_dba => $xref_dba,
+  dba => $core_dba,
+);
+
+populate_test_supporting_features($core_dba);
+
+my $rfam_mappings = $parser->get_rfam_supporting_features($core_dba);
+
+is ($rfam_mappings->{RF00000000}[0], 'ENST00000000001', 'Basic retrieval of supporting features for Rfam entities');
+# FIXME Needs more testing, but at least the basics work
+
+my $meta = $parser->parse_stockholm_format($test_file);
+
+is($meta->[0]{AC}, 'RF00001', 'First RFAM record parsed');
+is($meta->[1]{AC}, 'RF00002', 'Second RFAM record parsed');
+
+
+# Now that parsing and DB fetching have been tested individually, we can call run() and check the DB content
+
+$parser->run();
+
+my $result = $test_db->schema->resultset('Xref')->find({
+  accession => 'RF00001'
+});
+
+is ($result->label,'5S_rRNA','Attributes about first RFAM match stored');
+is ($result->description,'5S ribosomal RNA','Attributes about first RFAM match stored');
+
+$result = $test_db->schema->resultset('Xref')->find({
+  accession => 'RF00002'
+});
+
+ok(!$result, 'No stored xref for RFAM ID that did not have a supporting feature');
+
+done_testing();
+
+
+
+# returns a test transcript that will match a custom RFAM alignment
+sub populate_test_supporting_features {
+  my $dba = shift;
+
+  my $slice_adaptor = $dba->get_SliceAdaptor;
+
+  # Create an alignment and an analysis to make it findable
+  my $slice = $slice_adaptor->fetch_by_region('chromosome',1,100000,101000,1);
+
+  my $analysis_adaptor = $dba->get_AnalysisAdaptor;
+  
+  my $rfam_analysis = Bio::EnsEMBL::Analysis->new(
+    -logic_name => 'rfamblast',
+  );
+  my $dbid = $analysis_adaptor->store($rfam_analysis);
+
+  my $alignment = Bio::EnsEMBL::DnaDnaAlignFeature->new(
+    -slice => $slice,
+    -start => 1,
+    -end => 800,
+    -strand => 1,
+    -hseqname => 'RF00000000',  # a synthetic RFAM ID
+    -hstart => 51,
+    -hend => 851,
+    -hstrand => 1,
+    -analysis => $rfam_analysis,
+    -align_type => 'irrelevant',
+    -cigar_string => 'STOGIE'
+  );
+
+  my $alignment_adaptor = $dba->get_DnaAlignFeatureAdaptor;
+
+  $alignment_adaptor->store($alignment);
+
+  # Add some alignment features to match the Rfam.seed file
+
+  my $rfam_matching_alignment = Bio::EnsEMBL::DnaDnaAlignFeature->new(
+    -slice => $slice,
+    -start => 1,
+    -end => 800,
+    -strand => 1,
+    -hseqname => 'RF00001',  # a fake RFAM ID from the test file
+    -hstart => 51,
+    -hend => 851,
+    -hstrand => 1,
+    -analysis => $rfam_analysis,
+    -align_type => 'irrelevant',
+    -cigar_string => 'CUBAN'
+  );
+
+  $alignment_adaptor->store(
+    $rfam_matching_alignment  
+  );
+
+  # Not storing RF00002, so that we have a negative case
+
+  # Now create a non-coding transcript feature that matches coordinates with the alignment
+
+  my $gene_analysis = Bio::EnsEMBL::Analysis->new(
+    -logic_name => 'ncRNA',
+  );
+  $dbid = $analysis_adaptor->store($gene_analysis);
+
+
+  my $exon = Bio::EnsEMBL::Exon->new(
+    -slice => $slice,
+    -start => 1,
+    -end => 800,
+    -strand => 1,
+    -stable_id => 'ENSE00000000001',
+    -phase => 0,
+    -end_phase => 2
+  );
+
+  my $transcript = Bio::EnsEMBL::Transcript->new(
+    -exons => [ $exon ],
+    -stable_id => 'ENST00000000001',
+    -external_name => 'TheWorst',
+    -biotype => 'pseudogene',
+    -source => 'testing',
+    -analysis => $gene_analysis
+  );
+
+  my $transcript_adaptor = $dba->get_TranscriptAdaptor;
+  $transcript_adaptor->store($transcript);
+
+  my $gene = Bio::EnsEMBL::Gene->new(
+    -start => 1,
+    -end => 800,
+    -strand => 1,
+    -slice => $slice,
+    -stable_id => 'ENSG000000001',
+    -biotype => 'pseudogene',
+    -source => 'testing',
+    -analysis => $gene_analysis,
+    -transcripts => [$transcript]
+  );
+  my $gene_adaptor = $dba->get_GeneAdaptor;
+
+  $gene_adaptor->store($gene);
+
+
+  # Now create a supporting feature that links the alignment to the exon
+  my $sf_adaptor = $dba->get_SupportingFeatureAdaptor;
+  $sf_adaptor->store($exon->dbID, [$alignment, $rfam_matching_alignment]);
+
+  return $transcript;
+};

--- a/modules/t/rfam.t
+++ b/modules/t/rfam.t
@@ -120,7 +120,7 @@ sub populate_test_supporting_features {
     -hend => 851,
     -hstrand => 1,
     -analysis => $rfam_analysis,
-    -align_type => 'irrelevant',
+    -align_type => 'cigar', # Doesn't really matter here, but needs to be something
     -cigar_string => 'STOGIE'
   );
 
@@ -140,7 +140,7 @@ sub populate_test_supporting_features {
     -hend => 851,
     -hstrand => 1,
     -analysis => $rfam_analysis,
-    -align_type => 'irrelevant',
+    -align_type => 'cigar',
     -cigar_string => 'CUBAN'
   );
 

--- a/modules/t/rfam.t
+++ b/modules/t/rfam.t
@@ -94,7 +94,7 @@ done_testing();
 
 
 
-# returns a test transcript that will match a custom RFAM alignment
+# Generates features and DNAAlignFeatures that will match a custom RFAM alignment
 sub populate_test_supporting_features {
   my $dba = shift;
 
@@ -200,5 +200,5 @@ sub populate_test_supporting_features {
   my $sf_adaptor = $dba->get_SupportingFeatureAdaptor;
   $sf_adaptor->store($exon->dbID, [$alignment, $rfam_matching_alignment]);
 
-  return $transcript;
+  return;
 };

--- a/modules/t/test-data/rfam.seed
+++ b/modules/t/test-data/rfam.seed
@@ -1,0 +1,32 @@
+# STOCKHOLM 1.0
+
+#=GF AC   RF00001
+#=GF ID   5S_rRNA
+#=GF DE   5S ribosomal RNA
+#=GF AU   Griffiths-Jones SR; 0000-0001-6043-807X
+#Sample comment field?
+
+
+
+X01556.1/3-118           --CUUGAC-GA-U-C-AU-AGA----GC-G-U-U-G---GA----------A-CC
+-A----------C--CUG----A-UC----CCUUCC------CGA-ACUCA-GA-AGUGAA-A-----------------
+CGACGCA-U-C--G---CC--GAUG----GUAGUGUG----GGGUUUC-C-CCAUG-UGA---G---AGUA----GG-U-
+CA-UC--G-UCAAGC
+X55260.1/3-119           --UACGGC-GG-C-C-AU-AGC----GA-A-G-G-G---GA----------A-AU
+-A----------C--CCG----G-UC----CCAUCC------CGA-ACCCG-GA-AGUCAA-G-----------------
+CCCUUCA-G-C--G---CC--GAUG----GUACUGCAA---CCGAGAG-G-CUGUG-GGA---G---AGUA----GG-A-
+CG-CC--G-CCGGAC
+
+//
+# STOCKHOLM 1.0
+
+#=GF AC   RF00002
+#=GF ID   Really does not matter
+#=GF DE   It's here because we expect one
+
+
+
+CP004143.1/5593050-5593169         AGUCGCUGCAGCGACGGUGGG-CAUACCAGGCUCAUCGU-ACGGCCGUCGAUACACCAAUCGACGGC---CCUCUCCCCCGCGCAUACCUGGCUGCAGCGGCUGACUUUUUCUCCAGGGGCGGUC
+#=GC SS_cons                       ::<<<<<<______>>>>->>.-------(((((,,,,,,<<<<<<<<<<<<______>>>>>>>>>->>>,,,,,,,<<<<<<<________>>>->>>>,,,,,,,,,,,,,,,,)))-))::
+#=GC RF                            aGuCgccGcAGCaACggcGGg.caUACcacccccauCGUCgggGCggucGGcaCACCcgCCgaccGCuccccuucCCCcCGCGcAuACcugGCUgCaGCGgCugaCccUUuCcccuagggCggac
+//


### PR DESCRIPTION
## Description

RFAM parser, taken from its original branch and into a clean one. It consumes the RFAM seed file, ignoring almost all content, but uses the list of valid accessions to match against prior alignments stored in core DBs. The two lists of IDs are paired and direct Xrefs are created where they match.

## Use case

Xref pipeline

## Benefits

Success!

## Possible Drawbacks

Ignoring records with AC, ID and DE present may be too harsh. get_rfam_supporting_features should really be core API functionality

## Testing

New test added for rfam parser, with a fake rfam.seed file to work from. The test suite is already screwed, but this new bit works.
