### PR TITLE
miRBaseParser

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
@@ -52,6 +52,18 @@ my $crossreference_sources_of_interest = [
   'protein_id',
 ];
 
+# To save memory and processing time, when we process a record in the
+# extractor we only load into memory the fields we need. Moreover, the
+# same list can later on be used to confirm that we have indeed
+# encountered all the mandatory fields.
+# Note that care must be taken when adding new prefixes to this list
+# because some of them - for instance the Rx family of fields,
+# describing publications - are not compatible with the current way of
+# processing.
+my $mandatory_prefixes_of_interest
+  = [ 'ID', 'AC', 'DE', 'OX', 'PE', 'SQ', q{  }, ];
+my $optional_prefixes_of_interest
+  = [ 'GN', 'DR', 'RG', ];
 
 
 =head2 run
@@ -143,8 +155,10 @@ sub run {
 
   my $extractor = $extractor_class->new({
     'file_names' => $files,
-    'species_id' => $species_id,
-    'xref_dba'   => $xref_dba,
+    'mandatory_prefixes' => $mandatory_prefixes_of_interest,
+    'optional_prefixes'  => $optional_prefixes_of_interest,
+    'species_id'         => $species_id,
+    'xref_dba'           => $xref_dba,
   });
   my $transformer = $transformer_class->new({
     'accepted_crossreference_sources' => $crossreference_sources_of_interest,

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
@@ -38,10 +38,11 @@ my %source_name_for_section = (
 );
 
 # List of crossreference sources for which we want to create direct or
-# dependent xrefs along with matching links. This includes both
-# sources for crossreferences directly appearing in UniProt-KB files
-# and special sources (at present, 'Uniprot_gn' and 'protein_id')
-# xrefs for which are assembled in the transformer.
+# dependent xrefs along with matching links.
+# Note that this includes sources such as 'Uniprot_gn' and 'protein_id'
+# which do not actually appear in UniProt-KB files but which are
+# synthesised from other data; omitting them from this list simply
+# means they will not be generated.
 my $crossreference_sources_of_interest = [
   'ChEMBL',
   'EMBL',

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
@@ -37,6 +37,21 @@ my %source_name_for_section = (
   'TrEMBL'     => 'Uniprot/SPTREMBL',
 );
 
+# List of crossreference sources for which we want to create direct or
+# dependent xrefs along with matching links. This includes both
+# sources for crossreferences directly appearing in UniProt-KB files
+# and special sources (at present, 'Uniprot_gn' and 'protein_id')
+# xrefs for which are assembled in the transformer.
+my $crossreference_sources_of_interest = [
+  'ChEMBL',
+  'EMBL',
+  'Ensembl',
+  'MEROPS',
+  'PDB',
+  'Uniprot_gn',
+  'protein_id',
+];
+
 
 
 =head2 run
@@ -132,8 +147,9 @@ sub run {
     'xref_dba'   => $xref_dba,
   });
   my $transformer = $transformer_class->new({
-    'species_id' => $species_id,
-    'xref_dba'   => $xref_dba,
+    'accepted_crossreference_sources' => $crossreference_sources_of_interest,
+    'species_id'                      => $species_id,
+    'xref_dba'                        => $xref_dba,
   });
   my $loader = $loader_class->new({
     'batch_size'         => $loader_batch_size,

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser.pm
@@ -162,6 +162,7 @@ sub run {
   });
   my $transformer = $transformer_class->new({
     'accepted_crossreference_sources' => $crossreference_sources_of_interest,
+    'default_direct_xref_type'        => 'Translation',  # just in case
     'species_id'                      => $species_id,
     'xref_dba'                        => $xref_dba,
   });

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Extractor.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Extractor.pm
@@ -218,7 +218,7 @@ sub extract {
 
   # Only proceed if at least one taxon code in the entry maps
   # to the current species ID, and skip unreviewed entries.
-  if ( ( ! $self->_taxon_codes_match_species_id() )
+  if ( ( ! $self->_record_species_matches() )
        || ( $self->_entry_is_unreviewed( $accession_numbers ) ) ) {
     return 'SKIP';
   }
@@ -746,6 +746,16 @@ sub _get_taxon_codes {
   }
 
   return \@extracted_taxon_codes;
+}
+
+
+# Check if the species indicated in the current record matches the one
+# for which we are running the parser. Specific implementation might
+# vary depending on the input data.
+sub _record_species_matches {
+  my ( $self ) = @_;
+
+  return $self->_taxon_codes_match_species_id();
 }
 
 

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Extractor.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Extractor.pm
@@ -142,7 +142,8 @@ my %taxonomy_ids_from_taxdb_codes
                      mandatory_prefixes in the event of a prefix
                      having been declared in both;
                 - species_id
-                   - Ensembl ID of the species under
+                - species_name
+                   - Ensembl ID and/or name of the species under
                      consideration. Records pertaining to other
                      species will be quietly ignored.
                 - xref_dba
@@ -161,6 +162,7 @@ sub new {
   my $mandatory_prefixes = $arg_ref->{'mandatory_prefixes'} // [];
   my $optional_prefixes  = $arg_ref->{'optional_prefixes'}  // [];
   my $species_id         = $arg_ref->{'species_id'};
+  my $species_name       = $arg_ref->{'species_name'};
   my $xref_dba           = $arg_ref->{'xref_dba'};
 
   my $filename = $file_names->[0];
@@ -173,6 +175,7 @@ sub new {
     '_io_handle'           => $filehandle,
     'prefixes_of_interest' => {},
     'species_id'           => $species_id,
+    'species_name'         => $species_name,
     'xref_dba'             => $xref_dba,
   };
   my $class = ref $proto || $proto;

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Extractor/miRBase.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Extractor/miRBase.pm
@@ -1,0 +1,118 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+
+package Bio::EnsEMBL::Xref::Parser::UniProtParser::Extractor::miRBase;
+
+use strict;
+use warnings;
+
+use Carp;
+
+use parent qw( Bio::EnsEMBL::Xref::Parser::UniProtParser::Extractor );
+
+
+# In case of miRBase data, we want to use the generic miRNA identifier
+# as the description. We extract it from the ID field because while it
+# is also present in the DE field, we want the variant beginning with
+# three-letter species abbreviation and DE uses human-readable species
+# names.
+sub _get_description {  ## no critic (ProhibitUnusedPrivateSubroutines)
+  my ( $self ) = @_;
+
+  # Only one ID line per record in miRBase files
+  my $id_line = $self->{'record'}->{'ID'}->[0];
+  if ( ! defined $id_line ) {
+    # No ID -> no description. Should never happen in practice
+    # because the parser should mark ID as a mandatory field.
+    return;
+  }
+
+  my ( $mirna_id )
+    = ( $id_line =~ m{
+                       \A
+                       ( \S+ )
+                       \s+
+                   }msx );
+  if ( ! defined $mirna_id ) {
+    # A problem with the pattern? Make sure it is noticed.
+    confess "Failed to extract miRNA ID from:\n\t$id_line";
+  }
+
+  return $mirna_id;
+}
+
+
+# Even if there is anything counting as quality information in miRBase
+# records, we do not use it.
+sub _get_quality {  ## no critic (ProhibitUnusedPrivateSubroutines)
+  my ( $self ) = @_;
+
+  return {};
+}
+
+
+# miRBase-specific implementation of the species-match check: use the
+# full species name
+sub _record_species_matches {  ## no critic (ProhibitUnusedPrivateSubroutines)
+  my ( $self ) = @_;
+
+  return $self->_species_name_matches();
+}
+
+
+# Extract the full, human-readable species name from the DE line of
+# the miRBase record and see if it matches the one provided by the
+# xref pipeline.
+sub _species_name_matches {
+  my ( $self ) = @_;
+
+  # Only one DE line per record in miRBase files
+  my $de_line = $self->{'record'}->{'DE'}->[0];
+  if ( ! defined $de_line ) {
+    # No DE -> no species -> no match. Should never happen in practice
+    # because the parser should mark DE as a mandatory field.
+    return 0;
+  }
+
+  my ( $record_species )
+    = ( $de_line =~ m{
+                       \A
+                       ( .+ )
+                       \s+
+                       \S+  # miRNA identifier
+                       \s+
+                       stem
+                       [- ] # both are present in the data. Consistency!
+                       loop
+                   }msx );
+  if ( ! defined $record_species ) {
+    # A problem with the pattern? Make sure it is noticed.
+    confess "Failed to extract species from:\n\t$de_line";
+  }
+
+  # Make extracted species name match Ensembl formatting
+  $record_species = lc( $record_species );
+  $record_species =~ s{[ ]}{_}msx;
+
+  return ( $record_species eq $self->{'species_name'} );
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Extractor/miRBase.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Extractor/miRBase.pm
@@ -94,7 +94,7 @@ sub _species_name_matches {
   my ( $record_species )
     = ( $de_line =~ m{
                        \A
-                       ( .+ )
+                       ( [^\n]+ )
                        \s+
                        \S+  # miRNA identifier
                        \s+

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Transformer.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Transformer.pm
@@ -212,14 +212,16 @@ sub transform {
     = @{ $extracted_record->{'accession_numbers'} };
   my $source_id = $self->_get_source_id();
 
+  my $sequence_data = $extracted_record->{'sequence'};
+
   my $xref_graph_node
     = {
        'ACCESSION'     => $accession,
        'DESCRIPTION'   => $extracted_record->{'description'},
        'INFO_TYPE'     => 'SEQUENCE_MATCH',
        'LABEL'         => $accession,
-       'SEQUENCE'      => $extracted_record->{'sequence'},
-       'SEQUENCE_TYPE' => 'peptide',
+       'SEQUENCE'      => $sequence_data->{'seq'},
+       'SEQUENCE_TYPE' => $sequence_data->{'type'},
        'SOURCE_ID'     => $source_id,
        'SPECIES_ID'    => $self->{'species_id'},
        'STATUS'        => 'experimental',
@@ -395,7 +397,7 @@ sub _make_links_from_crossreferences {
           = {
              # We want translation ID and 'id' for these is TRANSCRIPT ID
              'STABLE_ID'    => $direct_ref->{'optional_info'}->[0],
-             'ENSEMBL_TYPE' => 'Translation',
+             'ENSEMBL_TYPE' => 'Translation',  # FIXME: this shouldn't be hardcoded!!!
              'LINKAGE_TYPE' => 'DIRECT',
              'SOURCE_ID'    => $self->_get_source_id( 'direct' ),
              'ACCESSION'    => $primary_xref->{'ACCESSION'},

--- a/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Transformer/miRBase.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/UniProtParser/Transformer/miRBase.pm
@@ -1,0 +1,63 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+
+package Bio::EnsEMBL::Xref::Parser::UniProtParser::Transformer::miRBase;
+
+use strict;
+use warnings;
+
+use Carp;
+
+use parent qw( Bio::EnsEMBL::Xref::Parser::UniProtParser::Transformer );
+
+
+# miRBase-specific implementation of the source-ID getter: just use
+# the one provided by the pipeline.
+sub _get_record_source_id {  ## no critic (ProhibitUnusedPrivateSubroutines)
+  my ( $self ) = @_;
+
+  return $self->{'general_source_id'};
+}
+
+
+# miRBase-specific implementation of the label getter: use the generic
+# miRNA identifier which the extractor provides in the description
+# field.
+sub _prepare_label {  ## no critic (ProhibitUnusedPrivateSubroutines)
+  my ( $self ) = @_;
+
+  return $self->{'extracted_record'}->{'description'};
+}
+
+
+# miRBase-specific implementation of the sequence getter: convert it
+# to uppercase and replace all uracils with thymines.
+sub _prepare_sequence {  ## no critic (ProhibitUnusedPrivateSubroutines)
+  my ( $self ) = @_;
+
+  my $sequence_string = $self->{'extracted_record'}->{'sequence'}->{'seq'};
+  $sequence_string = uc( $sequence_string );
+  $sequence_string =~ s{ U }{T}gmsx;
+
+  return $sequence_string;
+}
+
+
+1;

--- a/modules/Bio/EnsEMBL/Xref/Parser/miRBaseParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/miRBaseParser.pm
@@ -115,7 +115,7 @@ sub run {
   load $loader_class;
 
   my $extractor = $extractor_class->new({
-    'file_names' => $files,
+    'file_names'         => $files,
     'mandatory_prefixes' => $mandatory_prefixes_of_interest,
     'species_name'       => $species_name,
     'xref_dba'           => $xref_dba,

--- a/modules/Bio/EnsEMBL/Xref/Parser/miRBaseParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/miRBaseParser.pm
@@ -1,0 +1,157 @@
+=head1 LICENSE
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+
+package Bio::EnsEMBL::Xref::Parser::miRBaseParser;
+
+use strict;
+use warnings;
+
+use Carp;
+use Module::Load;
+
+use parent qw( Bio::EnsEMBL::Xref::Parser );
+
+
+my $DEFAULT_LOADER_BATCH_SIZE         = 1000;
+my $DEFAULT_LOADER_CHECKPOINT_SECONDS = 300;
+
+# To save memory and processing time, when we process a record in the
+# extractor we only load into memory the fields we need. Moreover, the
+# same list can later on be used to confirm that we have indeed
+# encountered all the mandatory fields.
+# Note that care must be taken when adding new prefixes to this list
+# because some of them - for instance the Rx family of fields,
+# describing publications - are not compatible with the current way of
+# processing.
+my $mandatory_prefixes_of_interest
+  = [ 'ID', 'AC', 'DE', 'SQ', q{  }, ];
+
+
+=head2 run
+
+  Arg [1]    : HashRef arguments for the parser:
+                - standard list of arguments from ParseSource
+                - extractor
+                   - name of class used to instantiate the extractor
+                - transformer
+                   - name of class used to instantiate the transformer
+                - loader
+                   - name of class used to instantiate the loader
+                - loader_batch_size
+                   - how many input records to process before
+                     submitting xrefs to the database
+                - loader_checkpoint_seconds
+                   - the maximum amount of seconds (modulo the time
+                     needed to process a single entry) xrefs are
+                     allowed to stay in the buffer before being
+                     submitted to the database regardless of the batch
+                     size
+  Example    : $mirbase_parser->run({ ... });
+  Description: Extract miRBase entries from text files downloaded from
+               the miRBase Web site, then insert corresponding xrefs
+               into the xref database.
+
+               For each miRBase stem loop we produce a single xref,
+               which will later on be sequence-matched to
+               Ensembl. Creation of xrefs for mature miRNAs is
+               not supported yet.
+
+               miRBase dat files have the same structure as UniProt
+               Knowledge Base dumps, which is why we use the same
+               parsing engine.
+
+  Return type: none
+  Exceptions : throws on all processing errors
+  Caller     : ParseSource in the xref pipeline
+  Status     : Stable
+
+=cut
+
+sub run {
+  my ( $self ) = @_;
+
+  my $general_source_id = $self->{source_id};
+  my $species_id        = $self->{species_id};
+  my $species_name      = $self->{species};
+  my $files             = $self->{files};
+  my $release_file      = $self->{rel_file};
+  my $verbose           = $self->{verbose} // 0;
+  my $xref_dba          = $self->{xref_dba};
+
+  my $loader_batch_size
+    = $self->{loader_batch_size}         // $DEFAULT_LOADER_BATCH_SIZE;
+  my $loader_checkpoint_seconds
+    = $self->{loader_checkpoint_seconds} // $DEFAULT_LOADER_CHECKPOINT_SECONDS;
+
+  # Try to control where ETL modules can come from, just in case
+  # someone does something really weird with configuration options.
+  my $extractor_class   = 'Bio::EnsEMBL::Xref::Parser::UniProtParser::';
+  my $transformer_class = 'Bio::EnsEMBL::Xref::Parser::UniProtParser::';
+  my $loader_class      = 'Bio::EnsEMBL::Xref::Parser::UniProtParser::';
+
+  $extractor_class   .= $self->{extractor_class}   // 'Extractor::miRBase';
+  $transformer_class .= $self->{transformer_class} // 'Transformer::miRBase';
+  $loader_class      .= $self->{loader_class}      // 'Loader';
+
+  load $extractor_class;
+  load $transformer_class;
+  load $loader_class;
+
+  my $extractor = $extractor_class->new({
+    'file_names' => $files,
+    'mandatory_prefixes' => $mandatory_prefixes_of_interest,
+    'species_name'       => $species_name,
+    'xref_dba'           => $xref_dba,
+  });
+  my $transformer = $transformer_class->new({
+    'general_source_id' => $general_source_id,
+    'species_id'        => $species_id,
+    'xref_dba'          => $xref_dba,
+  });
+  my $loader = $loader_class->new({
+    'batch_size'         => $loader_batch_size,
+    'checkpoint_seconds' => $loader_checkpoint_seconds,
+    'xref_dba'           => $xref_dba,
+  });
+
+ RECORD:
+  while ( $extractor->get_uniprot_record() ) {
+
+    my $extracted_record = $extractor->extract();
+    if ( $extracted_record eq 'SKIP' ) {
+      next RECORD;
+    }
+
+    my $transformed_data
+      = $transformer->transform( $extracted_record );
+
+    $loader->load( $transformed_data );
+
+  }
+
+  $extractor->finish();
+  $transformer->finish();
+  $loader->finish();
+
+  return;
+}
+
+
+1;


### PR DESCRIPTION
## Description

Add miRBaseParser to the new xref repository. This is a full rewrite rather than a refactoring, albeit a minimal one because it mostly uses the new UniProtParser under the bonnet.

## Use case

Turns out the structure of miRBase data is virtually identical to that of UniProt-KB dat files. Moreover, although the old miRBaseParser is considerably less complicated than the old UniProtParser (for one thing, it doesn't have to mess with crossreferences because it only produces primary, sequence-matched xrefs) it is already incompatible with BaseParser changes made in _ensembl:feature/xref_sprint_ and I doubt it having morphed into BaseAdaptor as well as subsequent further cleanup would help matters.

Compared the output of the new parser to that of the "really old" one (_i.e._ from _ensembl:master_) for human. No unexpected differences (there is one expected one, the old parser set _info_type_ of primary xrefs to MISC whereas the new one sets it to SEQUENCE_MATCH, for consistency with similar xrefs produced from UniProt data). Run time is similar.

## Benefits

Will be able to parse miRBase xrefs using the refactored xref pipeline.

## Possible Drawbacks

None?

## Testing

_Have you added/modified unit tests to test the changes?_

Not yet, this is a specialisation of the new UniProtParser so we should develop tests for the latter first.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes, no regression has been observed.