### PR TITLE
Document DBIC methods

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/DependentXref.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/DependentXref.pm
@@ -22,6 +22,17 @@ use warnings;
 
 use parent 'DBIx::Class::ResultSet';
 
+
+=head2 fetch_dependent_xref
+
+Description: A canned query for fetching dependent xrefs by accession
+             The result contains the result row from the query
+Example    : my $row = $db->schema->resultset('DependentXref')
+              ->fetch_dependent_xref("A0A075B6P5", "R-HSA-109582");
+Returntype : Bio::EnsEMBL::Xref::Schema::Result::DependentXref
+
+=cut
+
 sub fetch_dependent_xref {
   my ($self,$direct_accession,$dependent_accession) = @_;
 

--- a/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/Synonym.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/Synonym.pm
@@ -23,12 +23,15 @@ use warnings;
 
 use parent 'DBIx::Class::ResultSet';
 
-=head2
-Search for the given xref_id and synonym
-  {
-    xref_id => $params->{xref_id},
-    synonym => $params->{synonym},
-  }
+=head2 check_synonym
+
+Description: Search for the given xref_id and synonym. Just a coding shortcut
+Example    : my $exists = $schema->resultset('Synonym')->check_synonym({
+               xref_id => $params->{xref_id},
+               synonym => $params->{synonym}
+             });
+Returntype : Boolean - True if the synonymn was found 
+
 =cut
 
 sub check_synonym {

--- a/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/Xref.pm
+++ b/modules/Bio/EnsEMBL/Xref/Schema/ResultSet/Xref.pm
@@ -22,6 +22,21 @@ use warnings;
 
 use parent 'DBIx::Class::ResultSet';
 
+
+=head2 check_direct_xref
+
+Arg [1]    : Hashref of constraints for the xref, e.g. accession, label,
+             info_type etc. Can be any column in the schema
+Description: A query wrapper to reduce the call stack when checking a single
+             Xref is in the database
+Returntype : Boolean - True means the Xref was in the database
+
+Example    : $db->schema->resultset('Xref')->check_direct_xref({
+                accession => 'BOB'
+              });
+
+=cut
+
 sub check_direct_xref {
   my ($self,$params) = @_;
 

--- a/modules/Bio/EnsEMBL/Xref/Test/TestDB.pm
+++ b/modules/Bio/EnsEMBL/Xref/Test/TestDB.pm
@@ -67,6 +67,12 @@ around '_init_config' => sub {
 };
 
 
+=head2 DEMOLISH
+
+Description: It's a destructor. It cleans up databases left behind by the test
+             Behaviour is overridden with $self->reuse(1)
+
+=cut
 sub DEMOLISH {
   my $self = shift;
   if ($self->reuse == 0 && defined $self->config) {


### PR DESCRIPTION
## Description

In response to POD coverage errors on packages nobody else has edited

## Use case

POD is good?

## Benefits



## Possible Drawbacks

Undocumented Parser::run() methods are left alone, due to the extent to which other pull requests monkey around with them.

## Testing

Not really relevant