### PR TITLE
cannot call logic_name on undefined analysis

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/Parser/RefSeqCoordinateParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/RefSeqCoordinateParser.pm
@@ -125,7 +125,7 @@ sub run {
   my $aa_of = $of_dba->get_AnalysisAdaptor();
 
   # Not all species have refseq_import data, exit if not found
-  if (!defined $aa_of->fetch_by_logic_name('refseq_import')->logic_name) {
+  if (!defined $aa_of->fetch_by_logic_name('refseq_import')) {
     print "No data found for RefSeq_import. Skipping\n";
     return;
   }


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Some species have an otherfeatures database but no refseq_import analysis.
In this case, we just want to finish the parser early if there is no data to parse.
If the analysis does not exist, fetch_by_logic_name('refseq_import') will return undef, which is enough to check what we want. Calling logic_name on the undef object will cause the parser to fail.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
See above

## Benefits

_If applicable, describe the advantages the changes will have._
Works for species with an otherfeatures database but no refseq_import analysis

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
None that I noticed

## Testing

_Have you added/modified unit tests to test the changes?_
No tests modified. It might be possible to test by hiding the analysis table when running the parser, which would mimic not finding the analysis

_If so, do the tests pass/fail?_
NA

_Have you run the entire test suite and no regression was detected?_
NA

