### PR TITLE
capture correct RFAM accession

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/Parser/RFAMParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/RFAMParser.pm
@@ -202,8 +202,9 @@ sub get_rfam_supporting_features {
   while ($iterator->has_next()) {
     my $row = $iterator->next;
     # RFAM sequences align to 1+ transcripts
-    if ($row->[1] =~ /^RF\d+/) {
-      push @{ $rfam_mapping{$row->[1]} }, $row->[0];
+    if ($row->[1] =~ /^(RF\d+)/) {
+      my $accession = $1;
+      push @{ $rfam_mapping{$accession} }, $row->[0];
     }
   }
   return \%rfam_mapping;


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
RFAM data is extracted from the core database. The data is stored in the protein_align_feature table but the entry is not just the RFAM accession, so we need some regex to correctly capture the accession.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
RFAM data is extracted from the core database. The data is stored in the protein_align_feature table but the entry is not just the RFAM accession, so we need some regex to correctly capture the accession.

## Benefits

_If applicable, describe the advantages the changes will have._
RFAM parser stores RFAM xrefs

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_
RFAM test still passes

_Have you run the entire test suite and no regression was detected?_
NA
