### PR TITLE
use updated source entry

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/Parser/ReactomeUniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/ReactomeUniProtParser.pm
@@ -83,7 +83,7 @@ sub run {
   my $file = shift @{$files};
 
   my $reactome_source_id =
-    $xref_dba->get_source_id_for_source_name( "reactome_translation", "uniprot" );
+    $xref_dba->get_source_id_for_source_name( "reactome_translation" );
 
 #e.g.
 #A0A075B6P5  R-HSA-109582  https://reactome.org/PathwayBrowser/#/R-HSA-109582  Hemostasis  TAS  Homo sapiens


### PR DESCRIPTION
## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
Reactome is now split into two parsers, Reactome_ensembl and Reactome_uniprot
They have separate sources and parsers. As a result, the corresponding sources do not need the priority_description field any more to distinguish between the data sources.

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
Reactome data mapped via UniProt accessions is now extracted using source Reactome_translation and parser ReactomeUniProtParser.
We do not store a separate priority_description field any more to highlight that the data was extracted using UniProt

## Benefits

_If applicable, describe the advantages the changes will have._
Parser works

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_
reactome_uniprot.t passes

_Have you run the entire test suite and no regression was detected?_
NA

