### PR TITLE
add species_id where missing

### DIFF
--- a/modules/Bio/EnsEMBL/Xref/Parser/RefSeqGPFFParser.pm
+++ b/modules/Bio/EnsEMBL/Xref/Parser/RefSeqGPFFParser.pm
@@ -89,12 +89,12 @@ sub run {
 
   # get RefSeq source ids
   while (my ($source_prefix, $source_name) = each %{$self->{refseq_sources}}) {
-    $self->{source_ids}->{$source_name} = $xref_dba->get_source_id_for_source_name( $source_name, undef )
+    $self->{source_ids}->{$source_name} = $xref_dba->get_source_id_for_source_name( $source_name, 'refseq')
   }
 
   # get extra source ids
-  $self->{source_ids}->{EntrezGene} = $xref_dba->get_source_id_for_source_name( 'EntrezGene', undef );
-  $self->{source_ids}->{WikiGene} = $xref_dba->get_source_id_for_source_name( 'WikiGene', undef );
+  $self->{source_ids}->{EntrezGene} = $xref_dba->get_source_id_for_source_name( 'EntrezGene' );
+  $self->{source_ids}->{WikiGene} = $xref_dba->get_source_id_for_source_name( 'WikiGene' );
 
   # Retrieve existing RefSeq mRNA
   $self->{refseq_ids} = { %{$xref_dba->get_valid_codes('RefSeq_mRNA', $species_id )},
@@ -283,6 +283,7 @@ sub xref_from_record {
         SOURCE_ID         => $self->source_id_from_name('EntrezGene'),
         LINKAGE_SOURCE_ID => $acc_source_id,
         ACCESSION         => $gene_id,
+        SPECIES_ID        => $self->{species_id},
         LABEL             => $self->{entrez}->{$gene_id}
     };
 
@@ -290,6 +291,7 @@ sub xref_from_record {
         SOURCE_ID         => $self->source_id_from_name('WikiGene'),
         LINKAGE_SOURCE_ID => $acc_source_id,
         ACCESSION         => $gene_id,
+        SPECIES_ID        => $self->{species_id},
         LABEL             => $self->{entrez}->{$gene_id}
     };
 


### PR DESCRIPTION
retrieve correct refseq sources

## Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

_Using one or more sentences, describe in detail the proposed changes._
RefSeqGPFF was failing because dependent_xref did not have a species_id.
This is now correctly added at creation
Additionally, the data was stored for the wrong source, so we ensure it gets stored for priority_description 'refseq'

## Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
RefSeqGPFFParser was not working. It now works and stores the data with the correct source_id.

## Benefits

_If applicable, describe the advantages the changes will have._
It works

## Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._

## Testing

_Have you added/modified unit tests to test the changes?_
No

_If so, do the tests pass/fail?_
NA, the test case currently fails pending fixes from PR 55

_Have you run the entire test suite and no regression was detected?_
NA
